### PR TITLE
Add clipboard targeted for OSX

### DIFF
--- a/internal/clipboard/clipboard.go
+++ b/internal/clipboard/clipboard.go
@@ -30,14 +30,18 @@ func copyOSX(text string) error {
 	}
 
 	if err := cmd.Start(); err != nil {
+		pipe.Close()
 		return err
 	}
 
 	if _, err := pipe.Write([]byte(text)); err != nil {
+		pipe.Close()
+		cmd.Wait()
 		return err
 	}
 
 	if err := pipe.Close(); err != nil {
+		cmd.Wait()
 		return err
 	}
 

--- a/internal/clipboard/clipboard.go
+++ b/internal/clipboard/clipboard.go
@@ -1,0 +1,45 @@
+package clipboard
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+)
+
+var (
+	execCommand = exec.Command
+	runtimeGOOS = runtime.GOOS
+)
+
+// Copy copies text to the clipboard and returns an error if unsuccessful
+func Copy(text string) error {
+	switch runtimeGOOS {
+	case "darwin":
+		return copyOSX(text)
+	default:
+		return fmt.Errorf("unsupported platform: %s", runtimeGOOS)
+	}
+}
+
+// copyOSX copies text to clipboard on macOS
+func copyOSX(text string) error {
+	cmd := execCommand("pbcopy")
+	pipe, err := cmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	if _, err := pipe.Write([]byte(text)); err != nil {
+		return err
+	}
+
+	if err := pipe.Close(); err != nil {
+		return err
+	}
+
+	return cmd.Wait()
+}

--- a/internal/clipboard/clipboard_test.go
+++ b/internal/clipboard/clipboard_test.go
@@ -1,0 +1,159 @@
+package clipboard
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestCopy(t *testing.T) {
+	originalExecCommand := execCommand
+	originalRuntimeGOOS := runtimeGOOS
+	defer func() {
+		execCommand = originalExecCommand
+		runtimeGOOS = originalRuntimeGOOS
+	}()
+
+	tests := map[string]struct {
+		text    string
+		goos    string
+		mockCmd func(name string, args ...string) *exec.Cmd
+		wantErr bool
+		errMsg  string
+	}{
+		"darwin success": {
+			text: "test text",
+			goos: "darwin",
+			mockCmd: func(name string, args ...string) *exec.Cmd {
+				if name == "pbcopy" {
+					return exec.Command("true")
+				}
+				return nil
+			},
+			wantErr: false,
+		},
+		"darwin empty text": {
+			text: "",
+			goos: "darwin",
+			mockCmd: func(name string, args ...string) *exec.Cmd {
+				if name == "pbcopy" {
+					return exec.Command("true")
+				}
+				return nil
+			},
+			wantErr: false,
+		},
+		"darwin command not found": {
+			text: "test text",
+			goos: "darwin",
+			mockCmd: func(name string, args ...string) *exec.Cmd {
+				return exec.Command("/nonexistent/pbcopy")
+			},
+			wantErr: true,
+		},
+		"unsupported platform": {
+			text:    "test text",
+			goos:    "linux",
+			wantErr: true,
+			errMsg:  "unsupported platform: linux",
+		},
+		"windows platform": {
+			text:    "test text",
+			goos:    "windows",
+			wantErr: true,
+			errMsg:  "unsupported platform: windows",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			runtimeGOOS = tt.goos
+			if tt.mockCmd != nil {
+				execCommand = tt.mockCmd
+			}
+
+			err := Copy(tt.text)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Copy() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.errMsg != "" && err != nil && err.Error() != tt.errMsg {
+				t.Errorf("Copy() error = %v, want %v", err.Error(), tt.errMsg)
+			}
+		})
+	}
+}
+
+func TestCopyOSX(t *testing.T) {
+	originalExecCommand := execCommand
+	defer func() {
+		execCommand = originalExecCommand
+	}()
+
+	tests := map[string]struct {
+		text    string
+		mockCmd func(name string, args ...string) *exec.Cmd
+		wantErr bool
+	}{
+		"success": {
+			text: "clipboard content",
+			mockCmd: func(name string, args ...string) *exec.Cmd {
+				if name == "pbcopy" {
+					return exec.Command("cat")
+				}
+				return nil
+			},
+			wantErr: false,
+		},
+		"multiline text": {
+			text: "line1\nline2\nline3",
+			mockCmd: func(name string, args ...string) *exec.Cmd {
+				if name == "pbcopy" {
+					return exec.Command("cat")
+				}
+				return nil
+			},
+			wantErr: false,
+		},
+		"special characters": {
+			text: "text with 'quotes' and \"double quotes\" and $variables",
+			mockCmd: func(name string, args ...string) *exec.Cmd {
+				if name == "pbcopy" {
+					return exec.Command("cat")
+				}
+				return nil
+			},
+			wantErr: false,
+		},
+		"command fails": {
+			text: "test",
+			mockCmd: func(name string, args ...string) *exec.Cmd {
+				if name == "pbcopy" {
+					return exec.Command("false")
+				}
+				return nil
+			},
+			wantErr: true,
+		},
+		"command not found": {
+			text: "test",
+			mockCmd: func(name string, args ...string) *exec.Cmd {
+				return exec.Command("/nonexistent/command")
+			},
+			wantErr: true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			execCommand = tt.mockCmd
+
+			err := copyOSX(tt.text)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("copyOSX() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clipboard functionality for macOS, allowing users to copy text to the system clipboard.

* **Tests**
  * Introduced unit tests to verify clipboard copy functionality and error handling across different platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->