### PR TITLE
Add master password key source, encrypted export, and rekey command

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ While sesh overlaps a bit with tools like aws-vault, it goes further by offering
 
 - **Extensible Plugin Architecture** — Add new authentication providers with a single interface
 - **Dual Storage Backends** — macOS Keychain (default) or encrypted SQLite with AES-256-GCM and Argon2id key derivation (`SESH_BACKEND=sqlite`)
+- **Two Key Sources for SQLite** — macOS Keychain (default) or user-supplied master password (`SESH_KEY_SOURCE=password`) for fully cross-platform, keychain-free operation
+- **Encrypted Export** — Portable backups protected by a password, safe to transfer between machines (`--format encrypted`)
 - **Password Manager** — Store and retrieve passwords, API keys, TOTP secrets, and secure notes with full-text search
 - **Terminal-First Workflow** — Authenticate without leaving the terminal
 - **Smart TOTP Handling** — Generate current and next codes, handle time window edge cases automatically. Supports non-standard configs (SHA-256/SHA-512, 8 digits, custom periods) extracted from QR codes
@@ -44,7 +46,7 @@ While sesh overlaps a bit with tools like aws-vault, it goes further by offering
 
 ## Installation
 
-> **Platform:** The default backend (macOS Keychain) requires macOS. The SQLite backend (`SESH_BACKEND=sqlite`) uses pure-Go encryption and works on macOS, Linux, and Windows — though the encryption key is still stored in the macOS Keychain for now. Full cross-platform key management is planned.
+> **Platform:** The default backend (macOS Keychain) requires macOS. The SQLite backend (`SESH_BACKEND=sqlite`) uses pure-Go encryption and works on macOS, Linux, and Windows. By default it still stores the encryption key in the macOS Keychain, but setting `SESH_KEY_SOURCE=password` enables a master-password mode that is fully keychain-free and works on any platform.
 
 ```bash
 # Option 1: Install with Homebrew (macOS)
@@ -268,6 +270,30 @@ sesh -service aws
 
 # SQLite backend (AES-256-GCM encrypted, Argon2id key derivation)
 SESH_BACKEND=sqlite sesh -service password -list
+```
+
+#### Key Source (SQLite backend only)
+```bash
+# Default: master key stored in macOS Keychain (keychain-assisted)
+SESH_BACKEND=sqlite sesh -service password -list
+
+# Master password: key derived from passphrase, no keychain needed (cross-platform)
+SESH_BACKEND=sqlite SESH_KEY_SOURCE=password sesh -service password -list
+# → prompts for master password; first run asks twice for confirmation
+
+# Non-interactive (CI/scripting — exposes password to process env)
+SESH_BACKEND=sqlite SESH_KEY_SOURCE=password SESH_MASTER_PASSWORD=... sesh -service password -list
+```
+
+#### Encrypted Export / Import
+```bash
+# Export to a portable password-encrypted file (uses Argon2id + AES-256-GCM)
+sesh -service password -action export -format encrypted -file backup.enc
+# → prompts for password (twice for confirmation)
+
+# Import an encrypted backup
+sesh -service password -action import -format encrypted -file backup.enc
+# → prompts for password
 ```
 
 ## Documentation

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -203,8 +203,28 @@ sesh supports two storage backends, selectable via `SESH_BACKEND`:
 - Argon2id key derivation for per-entry keys
 - FTS5 full-text search across service, account, and description
 - Audit log table tracking all access, modifications, and deletions
-- Master encryption key stored in the macOS Keychain via `KeychainSource`
+- Pluggable master key source (see below)
 - WAL mode for concurrent read safety
+
+**Key sources.** The `database.KeySource` interface abstracts where the 256-bit master encryption key comes from:
+
+```go
+type KeySource interface {
+    GetEncryptionKey() ([]byte, error)
+    StoreEncryptionKey(key []byte) error
+    RequiresUserInput() bool
+    Name() string
+}
+```
+
+Two implementations:
+
+- **`KeychainSource`** (default) — reads the key from the macOS Keychain; first-run generates a random 256-bit key and stores it. macOS-only.
+- **`MasterPasswordSource`** (`SESH_KEY_SOURCE=password`) — derives the key from a user-supplied passphrase via Argon2id. The KDF salt, Argon2id parameters, and a verification blob live in a 0600 sidecar file (`passwords.key`) next to the database. The verification blob is AES-256-GCM ciphertext of a known constant; on unlock, GCM's authentication tag rejects wrong passwords immediately. No keychain dependency — works on macOS, Linux, and Windows.
+
+`main.go`'s `buildKeySource(dataDir)` selects between them based on `SESH_KEY_SOURCE`. The store doesn't know or care which source provided the key.
+
+**Encrypted export.** The password manager's `ExportEncrypted`/`ImportEncrypted` use the same primitives (Argon2id + AES-256-GCM) but with an independent per-export salt. The envelope is self-contained — the salt and parameters are embedded alongside the ciphertext — so encrypted exports are portable across machines and key sources.
 
 Binary path restrictions in practice
 ```bash

--- a/docs/SECURITY_MODEL.md
+++ b/docs/SECURITY_MODEL.md
@@ -85,7 +85,7 @@ Derives the master key from a user-supplied passphrase via Argon2id. **No keycha
 - **Verification blob**: AES-256-GCM encryption of the constant string `"sesh-verify"` using the derived key. On unlock, sesh re-derives the key from the supplied password and tries to decrypt this blob. GCM's authentication tag rejects wrong passwords immediately, without touching any real entries
 - **First run**: prompts for the master password twice (confirmation), generates the salt, derives the key, writes the sidecar
 - **Subsequent runs**: reads sidecar, prompts for password, verifies via the blob, returns the key
-- **Minimum password length**: 8 characters (baseline — users should choose longer)
+- **Minimum password length**: 8 characters. This is a **floor**, not a recommendation — it exists to reject obvious mistakes (empty input, fat-fingered short strings). With Argon2id at `m=64 MiB, t=3` and an attacker who has the sidecar, an 8-character lowercase-ASCII password is brute-forceable within days on commodity hardware. **Choose a passphrase**: four or more random words from a large wordlist (40+ bits of entropy) gives meaningful resistance; longer is better
 - **Non-interactive mode**: `SESH_MASTER_PASSWORD` env var bypasses the prompt (intended for CI/scripts only; exposes the password to the process environment)
 
 **Threat model.** An attacker with the DB file and sidecar can attempt offline brute-force using the public salt and params. At ~5 attempts/second, a strong passphrase (four random words from a large wordlist, 40+ bits of entropy) is resistant; a weak password is not. This is the same threat model as any password manager — the strength of the master password bounds the security of everything under it.

--- a/docs/SECURITY_MODEL.md
+++ b/docs/SECURITY_MODEL.md
@@ -66,11 +66,42 @@ The SQLite backend provides application-level encryption on top of file-system s
 - **AES-256-GCM**: Authenticated encryption for every stored entry
 - **Per-entry salts**: Each entry derives a unique encryption key from the master key + a random 16-byte salt
 - **Argon2id key derivation**: Memory-hard KDF for per-entry key derivation (16 MiB, 1 iteration, 1 thread). The KDF input is the 256-bit high-entropy master key (see below), *not* a user password — so these parameters are chosen for domain separation between entries rather than password stretching, and fall below OWASP's password-KDF minimums by design
-- **Master key in Keychain**: The 256-bit master encryption key is stored in the macOS Keychain, combining OS-level access control with application-level encryption. The key is hex-encoded (64 ASCII characters) before storage because the `security` command's tokenizer can't reliably round-trip raw random bytes; the key is decoded on read and zeroed after use
+- **Two key sources** (`SESH_KEY_SOURCE`): the master key can come from the macOS Keychain (default) or be derived from a user-supplied master password (see below)
 - **Key versioning**: Schema supports key rotation via `key_version` column and `key_metadata` table (rotation logic planned)
 - **FTS5 search**: Full-text search indexes service names, accounts, and descriptions — search queries never touch encrypted data
 - **Audit logging**: Append-only `audit_log` table records access, modification, and deletion events with timestamps
 - **WAL mode**: Write-ahead logging for safe concurrent reads
+
+##### Keychain key source (default)
+
+The 256-bit master encryption key is stored in the macOS Keychain, combining OS-level access control with application-level encryption. The key is hex-encoded (64 ASCII characters) before storage because the `security` command's tokenizer can't reliably round-trip raw random bytes; the key is decoded on read and zeroed after use.
+
+##### Master password key source (`SESH_KEY_SOURCE=password`)
+
+Derives the master key from a user-supplied passphrase via Argon2id. **No keychain involvement**, so the SQLite backend is fully cross-platform in this mode.
+
+- **KDF**: Argon2id with `t=3, m=64 MiB, p=4, keyLen=32`. These parameters exceed OWASP 2023 minimums (`t=1, m=47 MiB, p=1`) and make offline brute-force expensive (~200 ms per attempt)
+- **Sidecar file** `passwords.key` (next to the DB, 0600 permissions): stores the KDF salt (32 random bytes), algorithm params, and a verification blob. **No secrets.** Same public-info model as bcrypt/scrypt — salt and params are safe to expose
+- **Verification blob**: AES-256-GCM encryption of the constant string `"sesh-verify"` using the derived key. On unlock, sesh re-derives the key from the supplied password and tries to decrypt this blob. GCM's authentication tag rejects wrong passwords immediately, without touching any real entries
+- **First run**: prompts for the master password twice (confirmation), generates the salt, derives the key, writes the sidecar
+- **Subsequent runs**: reads sidecar, prompts for password, verifies via the blob, returns the key
+- **Minimum password length**: 8 characters (baseline — users should choose longer)
+- **Non-interactive mode**: `SESH_MASTER_PASSWORD` env var bypasses the prompt (intended for CI/scripts only; exposes the password to the process environment)
+
+**Threat model.** An attacker with the DB file and sidecar can attempt offline brute-force using the public salt and params. At ~5 attempts/second, a strong passphrase (four random words from a large wordlist, 40+ bits of entropy) is resistant; a weak password is not. This is the same threat model as any password manager — the strength of the master password bounds the security of everything under it.
+
+**Metadata exposure.** Even without the master password, an attacker with the DB file can read service names, account names, timestamps, and audit log entries — only the encrypted secret values are protected. Full-database encryption (SQLCipher-style) would require a CGo dependency and is not implemented.
+
+### Encrypted Export
+
+Exports produced with `--format encrypted` are wrapped in a portable envelope that anyone with the password can decrypt on any machine:
+
+- **Argon2id** key derivation with the same parameters as the master-password key source (`t=3, m=64 MiB, p=4`)
+- **AES-256-GCM** encryption of the JSON payload using the derived key
+- **Random 32-byte salt** per export — the same password produces different ciphertext each time
+- **Envelope format** (JSON): `{version, algorithm, salt, params, ciphertext}` — salt and params are public, matching the sidecar model
+
+Unencrypted exports (`--format json`, `--format csv`) write secrets in plaintext and are intended for local scripting. Encrypted exports are the right choice for backups, transferring between machines, or storing in any medium the user doesn't fully trust. Use a strong password — the same brute-force threat model applies as with the master-password key source.
 
 ### Why This Matters
 
@@ -79,7 +110,8 @@ Compare sesh's approach to alternatives:
 | Storage Method | Encryption | Access Control | User Experience |
 |----------------|------------|----------------|-----------------|
 | sesh (Keychain) | OS-level (AES-256) | OS-enforced binary binding | Transparent |
-| sesh (SQLite) | AES-256-GCM + Argon2id | File permissions + encryption key in Keychain | Transparent |
+| sesh (SQLite + Keychain key) | AES-256-GCM + Argon2id | File permissions + encryption key in Keychain | Transparent |
+| sesh (SQLite + master password) | AES-256-GCM + Argon2id | File permissions + passphrase required per invocation | Prompt on every run |
 | Config Files | None/Custom | File permissions only | Manual setup |
 | Environment Vars | None | Process inheritance | Leaks to children |
 | Corporate MFA Apps | Unknown | App-controlled | Privacy concerns |

--- a/docs/SECURITY_MODEL.md
+++ b/docs/SECURITY_MODEL.md
@@ -103,6 +103,16 @@ Exports produced with `--format encrypted` are wrapped in a portable envelope th
 
 Unencrypted exports (`--format json`, `--format csv`) write secrets in plaintext and are intended for local scripting. Encrypted exports are the right choice for backups, transferring between machines, or storing in any medium the user doesn't fully trust. Use a strong password — the same brute-force threat model applies as with the master-password key source.
 
+### Switching key sources (`sesh rekey`)
+
+`sesh rekey --to <source>` re-encrypts every entry under a different key source and swaps the result into place atomically. The cryptographic posture during and after a rekey:
+
+- **No plaintext-on-disk window.** Unlike the export-then-import workaround, rekey never writes a plaintext-equivalent file (an encrypted export still sits on disk encrypted only with the export password). All re-encryption happens in-process; only encrypted-at-rest databases ever touch the filesystem.
+- **Per-row salt regeneration.** Every entry gets a fresh per-row salt under the new key. Encrypted ciphertext changes for every row even when the plaintext is identical.
+- **Recoverable backup.** On success the original database is preserved at `<dbPath>.pre-rekey`. The user is responsible for deleting it once they've verified the new state works (`shred -u` recommended on traditional filesystems).
+- **Old key state is preserved deliberately.** When switching keychain → password, the old keychain entry is left in place (now unused); same for the sidecar when switching password → keychain. This gives an additional rollback path and avoids the situation where a partial failure has destroyed the user's only access to a recoverable backup. The summary message points at the manual cleanup paths.
+- **Refusal-over-overwrite for target state.** If the target's persistent state already exists (a stale sidecar, or a keychain entry left over from a prior switch), rekey refuses and asks the user to clean up manually. The reasoning: silent overwrite of a salt or stored key could destroy access to whatever the user originally had.
+
 ### Why This Matters
 
 Compare sesh's approach to alternatives:

--- a/docs/USAGE_AND_CONFIGURATION.md
+++ b/docs/USAGE_AND_CONFIGURATION.md
@@ -148,7 +148,7 @@ sesh uses a provider-based configuration system:
 | `-username`       | Username for the service                           | No               |
 | `-entry-type`     | Filter: password, api_key, totp, secure_note       | No               |
 | `-query`          | Search query                                       | For search       |
-| `-format`         | Output format: table (default), json, csv          | No               |
+| `-format`         | Output format for list/get/search: table (default), json. For export/import: json (default), csv, encrypted | No               |
 | `-show`           | Display password instead of clipboard hint         | No               |
 | `-file`           | File path for export/import (default: stdout/stdin)| No               |
 | `-on-conflict`    | Import conflict: skip, overwrite (default: error)  | No               |
@@ -161,10 +161,67 @@ sesh uses a provider-based configuration system:
 
 ### Environment Variables
 
-| Variable           | Description                                        | Default          |
-|--------------------|----------------------------------------------------|------------------|
-| `AWS_PROFILE`     | Default AWS profile                                | `default`        |
-| `SESH_BACKEND`    | Storage backend — only `sqlite` selects SQLite; any other value (or unset) uses the keychain | `keychain`       |
+| Variable                | Description                                        | Default          |
+|-------------------------|----------------------------------------------------|------------------|
+| `AWS_PROFILE`          | Default AWS profile                                | `default`        |
+| `SESH_BACKEND`         | Storage backend — only `sqlite` selects SQLite; any other value (or unset) uses the keychain | `keychain`       |
+| `SESH_KEY_SOURCE`      | Master key source for SQLite backend: `keychain` (default) or `password`. Ignored when `SESH_BACKEND` is not `sqlite` | `keychain`       |
+| `SESH_MASTER_PASSWORD` | Non-interactive master password (skips prompt). Intended for CI/scripting only — exposes the password via process environment | unset            |
+
+## Storage Backend and Key Source
+
+sesh has two independent axes:
+
+| Axis | Values | Selected by |
+|------|--------|-------------|
+| Backend | `keychain` (default) or `sqlite` | `SESH_BACKEND` |
+| Key source (SQLite only) | `keychain` (default) or `password` | `SESH_KEY_SOURCE` |
+
+The matrix:
+
+| `SESH_BACKEND` | `SESH_KEY_SOURCE` | Where data lives | Where key lives | Platforms |
+|---|---|---|---|---|
+| unset / `keychain` | (ignored) | macOS Keychain | macOS Keychain | macOS only |
+| `sqlite` | unset / `keychain` | SQLite file (encrypted) | macOS Keychain (256-bit random) | macOS only |
+| `sqlite` | `password` | SQLite file (encrypted) | Derived from master password via Argon2id; salt in `passwords.key` sidecar (0600) | macOS, Linux, Windows |
+
+### Using the master password mode
+
+```bash
+# First run — asked to create the password (twice for confirmation)
+SESH_BACKEND=sqlite SESH_KEY_SOURCE=password sesh --service password --action store \
+    --service-name github --username alice
+# Create master password: ****
+# Confirm master password: ****
+# Enter password for github (alice): ****
+
+# Subsequent runs — single prompt to unlock
+SESH_BACKEND=sqlite SESH_KEY_SOURCE=password sesh --service password --list
+# Master password: ****
+
+# Non-interactive (CI/scripts — prefer this only in trusted environments)
+export SESH_MASTER_PASSWORD='...'
+SESH_BACKEND=sqlite SESH_KEY_SOURCE=password sesh --service password --list
+```
+
+The sidecar file `passwords.key` lives next to the SQLite database. It contains the KDF salt, Argon2id parameters, and a verification blob (not a password hash) — nothing secret. Keep it with the database when moving between machines; without it, the database cannot be unlocked even with the correct password.
+
+### Encrypted exports
+
+Use `--format encrypted` to produce a portable, password-protected backup:
+
+```bash
+sesh --service password --action export --format encrypted --file backup.enc
+# Encryption password: ****
+# Confirm encryption password: ****
+# Exported 12 entries to backup.enc
+
+sesh --service password --action import --format encrypted --file backup.enc
+# Decryption password: ****
+# Imported 12 entries
+```
+
+Encrypted exports use the same Argon2id + AES-256-GCM primitives as the master password mode. The export is self-contained (envelope includes the salt and KDF params) and works across machines, key sources, and backends.
 
 ## Usage Patterns
 
@@ -296,13 +353,21 @@ sesh -service password -action search -query github
 # List with filters
 sesh -service password -list -entry-type api_key -sort updated_at
 
-# Export all entries
+# Export all entries (plaintext — local use only)
 sesh -service password -action export -file backup.json
 sesh -service password -action export -format csv -file backup.csv
+
+# Encrypted export (portable, password-protected with Argon2id + AES-256-GCM)
+sesh -service password -action export -format encrypted -file backup.enc
+# → prompts for password twice (confirmation)
 
 # Import entries
 sesh -service password -action import -file backup.json
 sesh -service password -action import -file data.csv -format csv -on-conflict skip
+
+# Import encrypted backup
+sesh -service password -action import -format encrypted -file backup.enc
+# → prompts for password
 
 # JSON output for scripting
 sesh -service password -action search -query stripe -format json

--- a/docs/USAGE_AND_CONFIGURATION.md
+++ b/docs/USAGE_AND_CONFIGURATION.md
@@ -223,6 +223,39 @@ sesh --service password --action import --format encrypted --file backup.enc
 
 Encrypted exports use the same Argon2id + AES-256-GCM primitives as the master password mode. The export is self-contained (envelope includes the salt and KDF params) and works across machines, key sources, and backends.
 
+### Switching key sources (`sesh rekey`)
+
+Switching `SESH_KEY_SOURCE` after entries exist would otherwise leave the database unreadable — the new source derives a different key. `sesh rekey --to <source>` re-encrypts every entry under the target key source and atomically swaps the result into place.
+
+```bash
+# Currently using keychain; switch to master password.
+SESH_BACKEND=sqlite sesh --rekey --to password
+# Create master password: ****
+# Confirm master password: ****
+# About to re-encrypt 12 entries: keychain → password
+#   source DB:           /Users/alice/Library/Application Support/sesh/passwords.db
+#   rollback file after: /Users/alice/Library/Application Support/sesh/passwords.db.pre-rekey
+#
+# Proceed? [y/N]: y
+# Rekeyed 12 entries: keychain → password
+# Original DB preserved at /Users/alice/Library/Application Support/sesh/passwords.db.pre-rekey
+# Note: old keychain entry 'sesh-sqlite-encryption-key' is now unused. Remove it via Keychain Access if you want to clean up.
+
+# Then run with the new source.
+export SESH_KEY_SOURCE=password
+SESH_BACKEND=sqlite sesh --service password --list
+```
+
+Behaviour:
+
+- **Atomic.** Either every entry is re-encrypted under the new source and the swap completes, or nothing changes. A copy failure cleans up the new key state and leaves the original database and original key state untouched.
+- **Recoverable.** On success, the original database is preserved at `<dbPath>.pre-rekey`. Verify the new state works, then remove the backup manually.
+- **Old key state is left in place.** Switching from keychain → password leaves the keychain entry; switching from password → keychain leaves the sidecar. Both become unused but are not auto-deleted (so you have an additional rollback path). The summary message points at how to clean them up.
+- **Refuses if the target is already initialised.** If a sidecar already exists for `--to password`, or a keychain entry already exists for `--to keychain`, rekey aborts and asks you to clean up manually before retrying.
+- **`--to <same as current>` is rejected.** Rotating within the same source (changing master password without switching) is not yet supported — use the encrypted-export route in the meantime.
+
+Timestamps (`created_at`, `updated_at`) are preserved across the rekey.
+
 ## Usage Patterns
 
 ### Basic Examples

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/makiuchi-d/gozxing v0.1.2-0.20250720151325-95e256b768ac
 	github.com/pquerna/otp v1.4.0
 	golang.org/x/crypto v0.49.0
+	golang.org/x/sync v0.20.0
 	golang.org/x/term v0.41.0
 	modernc.org/sqlite v1.48.1
 )

--- a/internal/database/master_password.go
+++ b/internal/database/master_password.go
@@ -77,9 +77,9 @@ func (s *MasterPasswordSource) sidecarPath() string {
 // for the lifetime of this source so repeated Get/Set operations within one
 // invocation do not re-prompt.
 //
-// The caller should NOT zero the returned slice — this source returns a
-// defensive copy so the cache remains intact. Call Close() to clear the
-// cached key when done.
+// Per the KeySource contract the caller is free to zero the returned slice
+// — the cache holds a private copy. Call Close() to clear the cached key
+// when done.
 func (s *MasterPasswordSource) GetEncryptionKey() ([]byte, error) {
 	if s.cachedKey != nil {
 		return cloneKey(s.cachedKey), nil
@@ -117,8 +117,11 @@ func (s *MasterPasswordSource) acquireKey() ([]byte, error) {
 // locks. After acquiring the lock, the sidecar is re-checked — another
 // process may have created it while this one was blocked.
 func (s *MasterPasswordSource) initializeLocked() ([]byte, error) {
+	if !filepath.IsAbs(s.dataDir) {
+		return nil, fmt.Errorf("data dir must be an absolute path, got %q", s.dataDir)
+	}
 	sentinel := s.sidecarPath() + ".lock"
-	lockFile, err := os.OpenFile(sentinel, os.O_CREATE|os.O_RDWR, 0o600) //nolint:gosec // path derived from caller-controlled dataDir
+	lockFile, err := os.OpenFile(sentinel, os.O_CREATE|os.O_RDWR, 0o600) //nolint:gosec // sentinel is <abs-dataDir>/passwords.key.lock; abs check above
 	if err != nil {
 		return nil, fmt.Errorf("open sidecar lock: %w", err)
 	}
@@ -216,10 +219,19 @@ func (s *MasterPasswordSource) unlock() ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("decode salt: %w", err)
 	}
+	if len(salt) < 16 {
+		return nil, fmt.Errorf("sidecar salt too short: %d bytes (min 16)", len(salt))
+	}
 
 	verifyBlob, err := base64.StdEncoding.DecodeString(data.Verify)
 	if err != nil {
 		return nil, fmt.Errorf("decode verify blob: %w", err)
+	}
+	// AES-GCM minimum: 12-byte nonce + 16-byte tag = 28 bytes (plaintext is
+	// extra). Short-circuit before prompting and burning ~200ms on Argon2id
+	// for a sidecar that can't possibly verify.
+	if len(verifyBlob) < 28 {
+		return nil, fmt.Errorf("sidecar verify blob too short: %d bytes", len(verifyBlob))
 	}
 
 	pw, err := s.promptFunc("Master password: ")
@@ -230,15 +242,12 @@ func (s *MasterPasswordSource) unlock() ([]byte, error) {
 
 	key := DeriveKey(pw, salt, data.Params)
 
-	plaintext, err := Decrypt(key, verifyBlob)
-	if err != nil {
+	// AES-GCM authentication is what guarantees "this plaintext was
+	// produced by encryption under this key" — a successful Decrypt is
+	// already proof of the right master password.
+	if _, err := Decrypt(key, verifyBlob); err != nil {
 		secure.SecureZeroBytes(key)
 		return nil, fmt.Errorf("wrong master password")
-	}
-
-	if string(plaintext) != verifyPlaintext {
-		secure.SecureZeroBytes(key)
-		return nil, fmt.Errorf("wrong master password (verify mismatch)")
 	}
 
 	return key, nil

--- a/internal/database/master_password.go
+++ b/internal/database/master_password.go
@@ -91,6 +91,10 @@ func (s *MasterPasswordSource) initialize() ([]byte, error) {
 	}
 	defer secure.SecureZeroBytes(pw)
 
+	if len(pw) < 8 {
+		return nil, fmt.Errorf("master password must be at least 8 characters")
+	}
+
 	confirm, err := s.promptFunc("Confirm master password: ")
 	if err != nil {
 		return nil, fmt.Errorf("read confirmation: %w", err)
@@ -99,10 +103,6 @@ func (s *MasterPasswordSource) initialize() ([]byte, error) {
 
 	if !bytes.Equal(pw, confirm) {
 		return nil, fmt.Errorf("passwords do not match")
-	}
-
-	if len(pw) < 8 {
-		return nil, fmt.Errorf("master password must be at least 8 characters")
 	}
 
 	salt, err := GenerateSalt(32)
@@ -180,9 +180,19 @@ func (s *MasterPasswordSource) writeSidecar(data sidecarData) error {
 		return fmt.Errorf("marshal sidecar: %w", err)
 	}
 
+	// Write to a temp file then rename so a crash mid-write leaves the
+	// old sidecar intact (or no sidecar at all on first run). Rename is
+	// atomic on POSIX and close-to-atomic on Windows.
 	path := s.sidecarPath()
-	if err := os.WriteFile(path, b, 0o600); err != nil {
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, b, 0o600); err != nil {
 		return fmt.Errorf("write sidecar: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		if rmErr := os.Remove(tmp); rmErr != nil && !os.IsNotExist(rmErr) {
+			return fmt.Errorf("replace sidecar: %w (cleanup of %s also failed: %v)", err, tmp, rmErr)
+		}
+		return fmt.Errorf("replace sidecar: %w", err)
 	}
 	return nil
 }
@@ -202,6 +212,35 @@ func (s *MasterPasswordSource) readSidecar() (sidecarData, error) {
 	if data.Version != sidecarVersion {
 		return sidecarData{}, fmt.Errorf("unsupported sidecar version %d (expected %d)", data.Version, sidecarVersion)
 	}
+	if data.Algorithm != "argon2id" {
+		return sidecarData{}, fmt.Errorf("unsupported sidecar algorithm %q", data.Algorithm)
+	}
+	if err := validateArgon2idBounds(data.Params); err != nil {
+		return sidecarData{}, err
+	}
 
 	return data, nil
+}
+
+// validateArgon2idBounds bounds-checks Argon2id parameters read from disk.
+// A corrupted or malicious sidecar could otherwise trigger a memory DoS.
+func validateArgon2idBounds(p Argon2idParams) error {
+	const (
+		maxMemoryKiB = 1 << 20 // 1 GiB
+		maxTime      = 10
+		maxThreads   = 16
+	)
+	if p.Memory == 0 || p.Memory > maxMemoryKiB {
+		return fmt.Errorf("sidecar memory param out of range: %d KiB (max %d)", p.Memory, maxMemoryKiB)
+	}
+	if p.Time == 0 || p.Time > maxTime {
+		return fmt.Errorf("sidecar time param out of range: %d (max %d)", p.Time, maxTime)
+	}
+	if p.Threads == 0 || p.Threads > maxThreads {
+		return fmt.Errorf("sidecar threads param out of range: %d (max %d)", p.Threads, maxThreads)
+	}
+	if p.KeyLen != 32 {
+		return fmt.Errorf("sidecar key_len must be 32, got %d", p.KeyLen)
+	}
+	return nil
 }

--- a/internal/database/master_password.go
+++ b/internal/database/master_password.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"syscall"
 
 	"github.com/bashhack/sesh/internal/secure"
@@ -46,7 +47,11 @@ type MasterPasswordSource struct {
 	// Scoped to the process lifetime only — cleared when Close() is called
 	// (or when the process exits). This avoids prompting the user on every
 	// Get/Set operation within a single invocation.
+	//
+	// mu guards cachedKey so a concurrent Close() can't zero the underlying
+	// memory while GetEncryptionKey is mid-clone.
 	cachedKey []byte
+	mu        sync.Mutex
 }
 
 // NewMasterPasswordSource creates a MasterPasswordSource that stores its
@@ -58,8 +63,11 @@ func NewMasterPasswordSource(dataDir string, prompt PasswordPromptFunc) *MasterP
 	}
 }
 
-// Close zeroes and releases the cached key. Safe to call multiple times.
+// Close zeroes and releases the cached key. Safe to call multiple times and
+// safe to call concurrently with GetEncryptionKey.
 func (s *MasterPasswordSource) Close() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.cachedKey != nil {
 		secure.SecureZeroBytes(s.cachedKey)
 		s.cachedKey = nil
@@ -81,16 +89,22 @@ func (s *MasterPasswordSource) sidecarPath() string {
 // — the cache holds a private copy. Call Close() to clear the cached key
 // when done.
 func (s *MasterPasswordSource) GetEncryptionKey() ([]byte, error) {
+	s.mu.Lock()
 	if s.cachedKey != nil {
-		return cloneKey(s.cachedKey), nil
+		clone := cloneKey(s.cachedKey)
+		s.mu.Unlock()
+		return clone, nil
 	}
+	s.mu.Unlock()
 
 	key, err := s.acquireKey()
 	if err != nil {
 		return nil, err
 	}
 
+	s.mu.Lock()
 	s.cachedKey = cloneKey(key)
+	s.mu.Unlock()
 	return key, nil
 }
 
@@ -134,10 +148,17 @@ func (s *MasterPasswordSource) initializeLocked() ([]byte, error) {
 		return nil, fmt.Errorf("acquire sidecar lock: %w", err)
 	}
 
-	if _, err := os.Stat(s.sidecarPath()); err == nil {
+	switch _, err := os.Stat(s.sidecarPath()); {
+	case err == nil:
 		return s.unlock()
+	case os.IsNotExist(err):
+		return s.initialize()
+	default:
+		// A non-IsNotExist error here (permission denied, I/O) shouldn't
+		// trigger a fresh init that could overwrite an existing-but-
+		// unreadable sidecar.
+		return nil, fmt.Errorf("re-check sidecar file: %w", err)
 	}
-	return s.initialize()
 }
 
 func cloneKey(k []byte) []byte {

--- a/internal/database/master_password.go
+++ b/internal/database/master_password.go
@@ -1,0 +1,207 @@
+package database
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/bashhack/sesh/internal/secure"
+)
+
+const (
+	sidecarFileName = "passwords.key"
+	sidecarVersion  = 1
+	verifyPlaintext = "sesh-verify"
+)
+
+// sidecarData is the on-disk format for the master password's KDF salt,
+// params, and verification blob. Nothing secret — the salt and params are
+// public (same model as bcrypt), and the verify blob is a known constant
+// encrypted with the derived key so we can check the password before
+// touching any real data.
+type sidecarData struct {
+	Salt      string         `json:"salt"`      // base64
+	Algorithm string         `json:"algorithm"` // "argon2id"
+	Verify    string         `json:"verify"`    // base64, AES-256-GCM(derived_key, "sesh-verify")
+	Params    Argon2idParams `json:"params"`
+	Version   int            `json:"version"`
+}
+
+// PasswordPromptFunc is called to obtain the master password from the user.
+// Implementations should not echo the input.
+type PasswordPromptFunc func(prompt string) ([]byte, error)
+
+// MasterPasswordSource derives the encryption key from a user-supplied
+// passphrase via Argon2id. The KDF salt and a verification blob are stored
+// in a sidecar file alongside the DB — no keychain involvement.
+type MasterPasswordSource struct {
+	promptFunc PasswordPromptFunc
+	dataDir    string
+}
+
+// NewMasterPasswordSource creates a MasterPasswordSource that stores its
+// sidecar in dataDir (typically the same directory as the SQLite DB).
+func NewMasterPasswordSource(dataDir string, prompt PasswordPromptFunc) *MasterPasswordSource {
+	return &MasterPasswordSource{
+		dataDir:    dataDir,
+		promptFunc: prompt,
+	}
+}
+
+func (s *MasterPasswordSource) sidecarPath() string {
+	return filepath.Join(s.dataDir, sidecarFileName)
+}
+
+// GetEncryptionKey prompts for the master password and derives the
+// encryption key. On first run (no sidecar), it prompts twice for
+// confirmation and creates the sidecar. On subsequent runs, it verifies the
+// password against the stored verification blob.
+func (s *MasterPasswordSource) GetEncryptionKey() ([]byte, error) {
+	path := s.sidecarPath()
+	_, err := os.Stat(path)
+
+	if os.IsNotExist(err) {
+		return s.initialize()
+	}
+	if err != nil {
+		return nil, fmt.Errorf("check sidecar file: %w", err)
+	}
+
+	return s.unlock()
+}
+
+// StoreEncryptionKey is a no-op for the master password source — the key is
+// derived from the password, not stored directly.
+func (s *MasterPasswordSource) StoreEncryptionKey(_ []byte) error {
+	return nil
+}
+
+func (s *MasterPasswordSource) RequiresUserInput() bool { return true }
+func (s *MasterPasswordSource) Name() string            { return "master-password" }
+
+// initialize handles the first-run case: prompt for password twice, generate
+// salt, derive key, write sidecar.
+func (s *MasterPasswordSource) initialize() ([]byte, error) {
+	pw, err := s.promptFunc("Create master password: ")
+	if err != nil {
+		return nil, fmt.Errorf("read password: %w", err)
+	}
+	defer secure.SecureZeroBytes(pw)
+
+	confirm, err := s.promptFunc("Confirm master password: ")
+	if err != nil {
+		return nil, fmt.Errorf("read confirmation: %w", err)
+	}
+	defer secure.SecureZeroBytes(confirm)
+
+	if !bytes.Equal(pw, confirm) {
+		return nil, fmt.Errorf("passwords do not match")
+	}
+
+	if len(pw) < 8 {
+		return nil, fmt.Errorf("master password must be at least 8 characters")
+	}
+
+	salt, err := GenerateSalt(32)
+	if err != nil {
+		return nil, err
+	}
+
+	params := DefaultArgon2idParams()
+	key := DeriveKey(pw, salt, params)
+
+	verifyBlob, err := Encrypt(key, []byte(verifyPlaintext))
+	if err != nil {
+		secure.SecureZeroBytes(key)
+		return nil, fmt.Errorf("create verify blob: %w", err)
+	}
+
+	data := sidecarData{
+		Version:   sidecarVersion,
+		Salt:      base64.StdEncoding.EncodeToString(salt),
+		Algorithm: "argon2id",
+		Params:    params,
+		Verify:    base64.StdEncoding.EncodeToString(verifyBlob),
+	}
+
+	if err := s.writeSidecar(data); err != nil {
+		secure.SecureZeroBytes(key)
+		return nil, err
+	}
+
+	return key, nil
+}
+
+// unlock handles the normal case: read sidecar, prompt for password, verify, return key.
+func (s *MasterPasswordSource) unlock() ([]byte, error) {
+	data, err := s.readSidecar()
+	if err != nil {
+		return nil, err
+	}
+
+	salt, err := base64.StdEncoding.DecodeString(data.Salt)
+	if err != nil {
+		return nil, fmt.Errorf("decode salt: %w", err)
+	}
+
+	verifyBlob, err := base64.StdEncoding.DecodeString(data.Verify)
+	if err != nil {
+		return nil, fmt.Errorf("decode verify blob: %w", err)
+	}
+
+	pw, err := s.promptFunc("Master password: ")
+	if err != nil {
+		return nil, fmt.Errorf("read password: %w", err)
+	}
+	defer secure.SecureZeroBytes(pw)
+
+	key := DeriveKey(pw, salt, data.Params)
+
+	plaintext, err := Decrypt(key, verifyBlob)
+	if err != nil {
+		secure.SecureZeroBytes(key)
+		return nil, fmt.Errorf("wrong master password")
+	}
+
+	if string(plaintext) != verifyPlaintext {
+		secure.SecureZeroBytes(key)
+		return nil, fmt.Errorf("wrong master password (verify mismatch)")
+	}
+
+	return key, nil
+}
+
+func (s *MasterPasswordSource) writeSidecar(data sidecarData) error {
+	b, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal sidecar: %w", err)
+	}
+
+	path := s.sidecarPath()
+	if err := os.WriteFile(path, b, 0o600); err != nil {
+		return fmt.Errorf("write sidecar: %w", err)
+	}
+	return nil
+}
+
+func (s *MasterPasswordSource) readSidecar() (sidecarData, error) {
+	path := s.sidecarPath()
+	b, err := os.ReadFile(path) //nolint:gosec // path is <dataDir>/passwords.key; dataDir is caller-controlled via NewMasterPasswordSource
+	if err != nil {
+		return sidecarData{}, fmt.Errorf("read sidecar: %w", err)
+	}
+
+	var data sidecarData
+	if err := json.Unmarshal(b, &data); err != nil {
+		return sidecarData{}, fmt.Errorf("parse sidecar: %w", err)
+	}
+
+	if data.Version != sidecarVersion {
+		return sidecarData{}, fmt.Errorf("unsupported sidecar version %d (expected %d)", data.Version, sidecarVersion)
+	}
+
+	return data, nil
+}

--- a/internal/database/master_password.go
+++ b/internal/database/master_password.go
@@ -40,6 +40,12 @@ type PasswordPromptFunc func(prompt string) ([]byte, error)
 type MasterPasswordSource struct {
 	promptFunc PasswordPromptFunc
 	dataDir    string
+
+	// cachedKey holds the derived key after the first successful unlock.
+	// Scoped to the process lifetime only — cleared when Close() is called
+	// (or when the process exits). This avoids prompting the user on every
+	// Get/Set operation within a single invocation.
+	cachedKey []byte
 }
 
 // NewMasterPasswordSource creates a MasterPasswordSource that stores its
@@ -51,6 +57,14 @@ func NewMasterPasswordSource(dataDir string, prompt PasswordPromptFunc) *MasterP
 	}
 }
 
+// Close zeroes and releases the cached key. Safe to call multiple times.
+func (s *MasterPasswordSource) Close() {
+	if s.cachedKey != nil {
+		secure.SecureZeroBytes(s.cachedKey)
+		s.cachedKey = nil
+	}
+}
+
 func (s *MasterPasswordSource) sidecarPath() string {
 	return filepath.Join(s.dataDir, sidecarFileName)
 }
@@ -58,19 +72,42 @@ func (s *MasterPasswordSource) sidecarPath() string {
 // GetEncryptionKey prompts for the master password and derives the
 // encryption key. On first run (no sidecar), it prompts twice for
 // confirmation and creates the sidecar. On subsequent runs, it verifies the
-// password against the stored verification blob.
+// password against the stored verification blob. The derived key is cached
+// for the lifetime of this source so repeated Get/Set operations within one
+// invocation do not re-prompt.
+//
+// The caller should NOT zero the returned slice — this source returns a
+// defensive copy so the cache remains intact. Call Close() to clear the
+// cached key when done.
 func (s *MasterPasswordSource) GetEncryptionKey() ([]byte, error) {
+	if s.cachedKey != nil {
+		return cloneKey(s.cachedKey), nil
+	}
+
 	path := s.sidecarPath()
 	_, err := os.Stat(path)
 
-	if os.IsNotExist(err) {
-		return s.initialize()
+	var key []byte
+	switch {
+	case os.IsNotExist(err):
+		key, err = s.initialize()
+	case err != nil:
+		return nil, fmt.Errorf("check sidecar file: %w", err)
+	default:
+		key, err = s.unlock()
 	}
 	if err != nil {
-		return nil, fmt.Errorf("check sidecar file: %w", err)
+		return nil, err
 	}
 
-	return s.unlock()
+	s.cachedKey = cloneKey(key)
+	return key, nil
+}
+
+func cloneKey(k []byte) []byte {
+	cp := make([]byte, len(k))
+	copy(cp, k)
+	return cp
 }
 
 // StoreEncryptionKey is a no-op for the master password source — the key is

--- a/internal/database/master_password.go
+++ b/internal/database/master_password.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"syscall"
 
 	"github.com/bashhack/sesh/internal/secure"
 )
@@ -84,24 +85,56 @@ func (s *MasterPasswordSource) GetEncryptionKey() ([]byte, error) {
 		return cloneKey(s.cachedKey), nil
 	}
 
-	path := s.sidecarPath()
-	_, err := os.Stat(path)
-
-	var key []byte
-	switch {
-	case os.IsNotExist(err):
-		key, err = s.initialize()
-	case err != nil:
-		return nil, fmt.Errorf("check sidecar file: %w", err)
-	default:
-		key, err = s.unlock()
-	}
+	key, err := s.acquireKey()
 	if err != nil {
 		return nil, err
 	}
 
 	s.cachedKey = cloneKey(key)
 	return key, nil
+}
+
+// acquireKey decides whether to initialize a new sidecar or unlock an
+// existing one. First-run is serialized via flock so two concurrent sesh
+// invocations can't each generate a different salt and orphan one
+// process's derived key. Once the sidecar exists, unlock is salt-stable
+// and lock-free.
+func (s *MasterPasswordSource) acquireKey() ([]byte, error) {
+	path := s.sidecarPath()
+	_, err := os.Stat(path)
+	switch {
+	case err == nil:
+		return s.unlock()
+	case !os.IsNotExist(err):
+		return nil, fmt.Errorf("check sidecar file: %w", err)
+	}
+	return s.initializeLocked()
+}
+
+// initializeLocked serializes concurrent first-run invocations with an
+// advisory flock on <dataDir>/passwords.key.lock. The flock is auto-
+// released when the holding process exits, so crashes don't leave stale
+// locks. After acquiring the lock, the sidecar is re-checked — another
+// process may have created it while this one was blocked.
+func (s *MasterPasswordSource) initializeLocked() ([]byte, error) {
+	sentinel := s.sidecarPath() + ".lock"
+	lockFile, err := os.OpenFile(sentinel, os.O_CREATE|os.O_RDWR, 0o600) //nolint:gosec // path derived from caller-controlled dataDir
+	if err != nil {
+		return nil, fmt.Errorf("open sidecar lock: %w", err)
+	}
+	defer func() {
+		if cerr := lockFile.Close(); cerr != nil {
+			fmt.Fprintf(os.Stderr, "warning: release sidecar lock: %v\n", cerr)
+		}
+	}()
+	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX); err != nil {
+		return nil, fmt.Errorf("acquire sidecar lock: %w", err)
+	}
+
+	if _, err := os.Stat(s.sidecarPath()); err == nil {
+		return s.unlock()
+	}
+	return s.initialize()
 }
 
 func cloneKey(k []byte) []byte {

--- a/internal/database/master_password.go
+++ b/internal/database/master_password.go
@@ -53,10 +53,15 @@ type MasterPasswordSource struct {
 	// (or when the process exits). This avoids prompting the user on every
 	// Get/Set operation within a single invocation.
 	//
-	// mu guards cachedKey so a concurrent Close() can't zero the underlying
-	// memory while GetEncryptionKey is mid-clone.
-	cachedKey []byte
-	mu        sync.Mutex
+	// mu guards cachedKey + cacheEpoch so a concurrent Close() can't zero
+	// the underlying memory while GetEncryptionKey is mid-clone. cacheEpoch
+	// fences a slow Argon2id derivation that started before Close from
+	// writing into the (now-cleared) cache after Close returns — the
+	// derivation still returns its key to its caller, but the cache stays
+	// clean past shutdown.
+	cachedKey  []byte
+	mu         sync.Mutex
+	cacheEpoch uint64
 }
 
 // NewMasterPasswordSource creates a MasterPasswordSource that stores its
@@ -69,10 +74,12 @@ func NewMasterPasswordSource(dataDir string, prompt PasswordPromptFunc) *MasterP
 }
 
 // Close zeroes and releases the cached key. Safe to call multiple times and
-// safe to call concurrently with GetEncryptionKey.
+// safe to call concurrently with GetEncryptionKey. Bumping cacheEpoch fences
+// any in-flight derivation from re-populating the cache after Close returns.
 func (s *MasterPasswordSource) Close() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.cacheEpoch++
 	if s.cachedKey != nil {
 		secure.SecureZeroBytes(s.cachedKey)
 		s.cachedKey = nil
@@ -94,8 +101,11 @@ func (s *MasterPasswordSource) sidecarPath() string {
 // — the cache holds a private copy. Call Close() to clear the cached key
 // when done.
 func (s *MasterPasswordSource) GetEncryptionKey() ([]byte, error) {
-	// Fast path: cache hit. Lock only to read the slot and clone.
+	// Fast path: cache hit. Lock only to read the slot and clone. Capture
+	// the epoch so a Close that fires while we're in the slow path can
+	// invalidate our cache write.
 	s.mu.Lock()
+	epoch := s.cacheEpoch
 	if s.cachedKey != nil {
 		clone := cloneKey(s.cachedKey)
 		s.mu.Unlock()
@@ -123,7 +133,12 @@ func (s *MasterPasswordSource) GetEncryptionKey() ([]byte, error) {
 			return nil, err
 		}
 		s.mu.Lock()
-		s.cachedKey = cloneKey(key)
+		// Only populate the cache if no Close ran while we were deriving.
+		// If the epoch advanced, return the key to the caller but keep the
+		// cache clean — preserves the "cache cleared after Close" guarantee.
+		if s.cacheEpoch == epoch && s.cachedKey == nil {
+			s.cachedKey = cloneKey(key)
+		}
 		s.mu.Unlock()
 		return key, nil
 	})

--- a/internal/database/master_password.go
+++ b/internal/database/master_password.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"syscall"
 
+	"golang.org/x/sync/singleflight"
+
 	"github.com/bashhack/sesh/internal/secure"
 )
 
@@ -40,9 +42,12 @@ type PasswordPromptFunc func(prompt string) ([]byte, error)
 // passphrase via Argon2id. The KDF salt and a verification blob are stored
 // in a sidecar file alongside the DB — no keychain involvement.
 type MasterPasswordSource struct {
+	// sf collapses concurrent slow-path Gets into a single Argon2id
+	// derivation. Without it, N goroutines arriving with an empty cache
+	// would each fire ~64 MiB of Argon2id work in parallel.
+	sf         singleflight.Group
 	promptFunc PasswordPromptFunc
 	dataDir    string
-
 	// cachedKey holds the derived key after the first successful unlock.
 	// Scoped to the process lifetime only — cleared when Close() is called
 	// (or when the process exits). This avoids prompting the user on every
@@ -89,6 +94,7 @@ func (s *MasterPasswordSource) sidecarPath() string {
 // — the cache holds a private copy. Call Close() to clear the cached key
 // when done.
 func (s *MasterPasswordSource) GetEncryptionKey() ([]byte, error) {
+	// Fast path: cache hit. Lock only to read the slot and clone.
 	s.mu.Lock()
 	if s.cachedKey != nil {
 		clone := cloneKey(s.cachedKey)
@@ -97,15 +103,36 @@ func (s *MasterPasswordSource) GetEncryptionKey() ([]byte, error) {
 	}
 	s.mu.Unlock()
 
-	key, err := s.acquireKey()
+	// Slow path: collapse concurrent callers into a single acquireKey via
+	// singleflight. Without this, N goroutines hitting an empty cache would
+	// each run a full Argon2id derivation in parallel, multiplying CPU and
+	// memory pressure (and exploding race-detector runtime).
+	v, err, _ := s.sf.Do("acquire", func() (any, error) {
+		// A waiter from this same in-flight group may already have
+		// re-populated the cache; re-check before re-deriving.
+		s.mu.Lock()
+		if s.cachedKey != nil {
+			clone := cloneKey(s.cachedKey)
+			s.mu.Unlock()
+			return clone, nil
+		}
+		s.mu.Unlock()
+
+		key, err := s.acquireKey()
+		if err != nil {
+			return nil, err
+		}
+		s.mu.Lock()
+		s.cachedKey = cloneKey(key)
+		s.mu.Unlock()
+		return key, nil
+	})
 	if err != nil {
 		return nil, err
 	}
-
-	s.mu.Lock()
-	s.cachedKey = cloneKey(key)
-	s.mu.Unlock()
-	return key, nil
+	// The shared value is read by every waiter; clone so each caller can
+	// safely zero its own copy without affecting siblings or the cache.
+	return cloneKey(v.([]byte)), nil
 }
 
 // acquireKey decides whether to initialize a new sidecar or unlock an

--- a/internal/database/master_password_test.go
+++ b/internal/database/master_password_test.go
@@ -124,6 +124,58 @@ func TestMasterPasswordSource_Name(t *testing.T) {
 	}
 }
 
+func TestMasterPasswordSource_UnsupportedVersion(t *testing.T) {
+	dir := t.TempDir()
+	bad := []byte(`{"version": 99, "algorithm": "argon2id", "salt": "", "params": {"time":3,"memory":65536,"threads":4,"key_len":32}, "verify": ""}`)
+	if err := os.WriteFile(filepath.Join(dir, sidecarFileName), bad, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	src := NewMasterPasswordSource(dir, staticPrompt("any-password"))
+	_, err := src.GetEncryptionKey()
+	if err == nil {
+		t.Fatal("expected error for unsupported version")
+	}
+}
+
+func TestMasterPasswordSource_UnsupportedAlgorithm(t *testing.T) {
+	dir := t.TempDir()
+	bad := []byte(`{"version": 1, "algorithm": "scrypt", "salt": "", "params": {"time":3,"memory":65536,"threads":4,"key_len":32}, "verify": ""}`)
+	if err := os.WriteFile(filepath.Join(dir, sidecarFileName), bad, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	src := NewMasterPasswordSource(dir, staticPrompt("any-password"))
+	_, err := src.GetEncryptionKey()
+	if err == nil {
+		t.Fatal("expected error for unsupported algorithm")
+	}
+}
+
+func TestMasterPasswordSource_RejectsOutOfRangeParams(t *testing.T) {
+	tests := map[string]string{
+		"zero memory":   `{"version":1,"algorithm":"argon2id","salt":"","verify":"","params":{"time":3,"memory":0,"threads":4,"key_len":32}}`,
+		"huge memory":   `{"version":1,"algorithm":"argon2id","salt":"","verify":"","params":{"time":3,"memory":2147483647,"threads":4,"key_len":32}}`,
+		"zero threads":  `{"version":1,"algorithm":"argon2id","salt":"","verify":"","params":{"time":3,"memory":65536,"threads":0,"key_len":32}}`,
+		"huge time":     `{"version":1,"algorithm":"argon2id","salt":"","verify":"","params":{"time":999,"memory":65536,"threads":4,"key_len":32}}`,
+		"wrong key_len": `{"version":1,"algorithm":"argon2id","salt":"","verify":"","params":{"time":3,"memory":65536,"threads":4,"key_len":16}}`,
+	}
+
+	for name, body := range tests {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, sidecarFileName), []byte(body), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			src := NewMasterPasswordSource(dir, staticPrompt("any-password"))
+			_, err := src.GetEncryptionKey()
+			if err == nil {
+				t.Fatal("expected error for out-of-range params")
+			}
+		})
+	}
+}
+
 func TestMasterPasswordSource_SidecarHasNoSecrets(t *testing.T) {
 	dir := t.TempDir()
 	password := "super-secret-password-12345"

--- a/internal/database/master_password_test.go
+++ b/internal/database/master_password_test.go
@@ -2,9 +2,13 @@ package database
 
 import (
 	"bytes"
+	"encoding/hex"
 	"errors"
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"sync"
 	"testing"
 )
 
@@ -218,6 +222,116 @@ func TestMasterPasswordSource_CachesKeyAcrossCalls(t *testing.T) {
 	}
 	if !bytes.Equal(key1, key3) {
 		t.Fatal("same password should still yield same key")
+	}
+}
+
+func TestMasterPasswordSource_ConcurrentFirstRunSerialized(t *testing.T) {
+	dir := t.TempDir()
+	password := "concurrent-test-password"
+
+	var prompt PasswordPromptFunc = func(_ string) ([]byte, error) {
+		return []byte(password), nil
+	}
+
+	const N = 4
+	keys := make([][]byte, N)
+	errs := make([]error, N)
+
+	var start sync.WaitGroup
+	var done sync.WaitGroup
+	start.Add(1)
+	done.Add(N)
+
+	for i := range N {
+		go func(idx int) {
+			defer done.Done()
+			src := NewMasterPasswordSource(dir, prompt)
+			start.Wait()
+			keys[idx], errs[idx] = src.GetEncryptionKey()
+		}(i)
+	}
+	start.Done()
+	done.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("goroutine %d: %v", i, err)
+		}
+	}
+
+	for i := 1; i < N; i++ {
+		if !bytes.Equal(keys[0], keys[i]) {
+			t.Fatalf("goroutine %d derived a different key — flock did not serialize first run", i)
+		}
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, sidecarFileName)); err != nil {
+		t.Fatalf("sidecar missing after concurrent init: %v", err)
+	}
+}
+
+func TestMasterPasswordSourceHelperProcess(t *testing.T) {
+	if os.Getenv("SESH_TEST_MP_HELPER") != "1" {
+		return
+	}
+	dir := os.Getenv("SESH_TEST_MP_DIR")
+	password := os.Getenv("SESH_TEST_MP_PASSWORD")
+
+	src := NewMasterPasswordSource(dir, func(_ string) ([]byte, error) {
+		return []byte(password), nil
+	})
+
+	key, err := src.GetEncryptionKey()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	fmt.Print(hex.EncodeToString(key))
+	os.Exit(0)
+}
+
+func TestMasterPasswordSource_ConcurrentFirstRunMultiProcess(t *testing.T) {
+	dir := t.TempDir()
+	password := "multi-process-test-password"
+
+	const N = 4
+	cmds := make([]*exec.Cmd, N)
+	outs := make([]*bytes.Buffer, N)
+	errs := make([]*bytes.Buffer, N)
+
+	for i := range N {
+		cmd := exec.Command(os.Args[0], "-test.run=TestMasterPasswordSourceHelperProcess") //nolint:gosec // os.Args[0] is the test binary itself
+		cmd.Env = append(os.Environ(),
+			"SESH_TEST_MP_HELPER=1",
+			"SESH_TEST_MP_DIR="+dir,
+			"SESH_TEST_MP_PASSWORD="+password,
+		)
+		outs[i] = &bytes.Buffer{}
+		errs[i] = &bytes.Buffer{}
+		cmd.Stdout = outs[i]
+		cmd.Stderr = errs[i]
+		cmds[i] = cmd
+	}
+
+	for i, c := range cmds {
+		if err := c.Start(); err != nil {
+			t.Fatalf("start process %d: %v", i, err)
+		}
+	}
+	for i, c := range cmds {
+		if err := c.Wait(); err != nil {
+			t.Fatalf("process %d failed: %v\nstderr: %s", i, err, errs[i].String())
+		}
+	}
+
+	first := outs[0].String()
+	if first == "" {
+		t.Fatal("process 0 produced no key output")
+	}
+	for i := 1; i < N; i++ {
+		if outs[i].String() != first {
+			t.Fatalf("process %d derived a different key — flock did not serialize across processes\n  process 0: %s\n  process %d: %s", i, first, i, outs[i].String())
+		}
 	}
 }
 

--- a/internal/database/master_password_test.go
+++ b/internal/database/master_password_test.go
@@ -176,6 +176,51 @@ func TestMasterPasswordSource_RejectsOutOfRangeParams(t *testing.T) {
 	}
 }
 
+func TestMasterPasswordSource_CachesKeyAcrossCalls(t *testing.T) {
+	dir := t.TempDir()
+	password := "repeat-test-password"
+
+	callCount := 0
+	prompt := func(_ string) ([]byte, error) {
+		callCount++
+		return []byte(password), nil
+	}
+
+	src := NewMasterPasswordSource(dir, prompt)
+
+	// First call: prompts twice (create + confirm), derives key
+	key1, err := src.GetEncryptionKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstRunCalls := callCount
+
+	// Second call: cache hit, no prompt
+	key2, err := src.GetEncryptionKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if callCount != firstRunCalls {
+		t.Fatalf("expected no additional prompts after cache hit, got %d (was %d)", callCount, firstRunCalls)
+	}
+	if !bytes.Equal(key1, key2) {
+		t.Fatal("cached key should match first-call key")
+	}
+
+	// Close clears the cache — next call prompts again
+	src.Close()
+	key3, err := src.GetEncryptionKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if callCount == firstRunCalls {
+		t.Fatal("expected prompt after Close() clears cache")
+	}
+	if !bytes.Equal(key1, key3) {
+		t.Fatal("same password should still yield same key")
+	}
+}
+
 func TestMasterPasswordSource_SidecarHasNoSecrets(t *testing.T) {
 	dir := t.TempDir()
 	password := "super-secret-password-12345"

--- a/internal/database/master_password_test.go
+++ b/internal/database/master_password_test.go
@@ -1,0 +1,144 @@
+package database
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func staticPrompt(passwords ...string) PasswordPromptFunc {
+	i := 0
+	return func(_ string) ([]byte, error) {
+		if i >= len(passwords) {
+			return nil, errors.New("no more passwords")
+		}
+		pw := []byte(passwords[i])
+		i++
+		return pw, nil
+	}
+}
+
+func TestMasterPasswordSource_FirstRunCreatesSidecar(t *testing.T) {
+	dir := t.TempDir()
+	src := NewMasterPasswordSource(dir, staticPrompt("correct-horse-battery-staple", "correct-horse-battery-staple"))
+
+	key, err := src.GetEncryptionKey()
+	if err != nil {
+		t.Fatalf("GetEncryptionKey: %v", err)
+	}
+	if len(key) != 32 {
+		t.Fatalf("expected 32-byte key, got %d", len(key))
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, sidecarFileName)); err != nil {
+		t.Fatalf("sidecar should exist after first run: %v", err)
+	}
+}
+
+func TestMasterPasswordSource_SidecarPermissions(t *testing.T) {
+	dir := t.TempDir()
+	src := NewMasterPasswordSource(dir, staticPrompt("hunter2-password-secure", "hunter2-password-secure"))
+
+	if _, err := src.GetEncryptionKey(); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Stat(filepath.Join(dir, sidecarFileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("sidecar permissions should be 0600, got %o", perm)
+	}
+}
+
+func TestMasterPasswordSource_SecondRunReturnsSameKey(t *testing.T) {
+	dir := t.TempDir()
+	password := "my-master-password"
+
+	src1 := NewMasterPasswordSource(dir, staticPrompt(password, password))
+	key1, err := src1.GetEncryptionKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	src2 := NewMasterPasswordSource(dir, staticPrompt(password))
+	key2, err := src2.GetEncryptionKey()
+	if err != nil {
+		t.Fatalf("second unlock: %v", err)
+	}
+
+	if !bytes.Equal(key1, key2) {
+		t.Fatal("same password should yield same key across runs")
+	}
+}
+
+func TestMasterPasswordSource_WrongPasswordRejected(t *testing.T) {
+	dir := t.TempDir()
+
+	src1 := NewMasterPasswordSource(dir, staticPrompt("original", "original"))
+	if _, err := src1.GetEncryptionKey(); err != nil {
+		t.Fatal(err)
+	}
+
+	src2 := NewMasterPasswordSource(dir, staticPrompt("wrong-password"))
+	_, err := src2.GetEncryptionKey()
+	if err == nil {
+		t.Fatal("expected error for wrong password")
+	}
+}
+
+func TestMasterPasswordSource_MismatchedConfirmation(t *testing.T) {
+	dir := t.TempDir()
+	src := NewMasterPasswordSource(dir, staticPrompt("first-password", "different-password"))
+
+	_, err := src.GetEncryptionKey()
+	if err == nil {
+		t.Fatal("expected error for mismatched confirmation")
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, sidecarFileName)); !os.IsNotExist(err) {
+		t.Fatal("sidecar should not be created when confirmation fails")
+	}
+}
+
+func TestMasterPasswordSource_RejectsTooShortPassword(t *testing.T) {
+	dir := t.TempDir()
+	src := NewMasterPasswordSource(dir, staticPrompt("short", "short"))
+
+	_, err := src.GetEncryptionKey()
+	if err == nil {
+		t.Fatal("expected error for too-short password")
+	}
+}
+
+func TestMasterPasswordSource_Name(t *testing.T) {
+	src := NewMasterPasswordSource("/tmp", staticPrompt())
+	if src.Name() != "master-password" {
+		t.Errorf("expected 'master-password', got %q", src.Name())
+	}
+	if !src.RequiresUserInput() {
+		t.Error("RequiresUserInput should return true")
+	}
+}
+
+func TestMasterPasswordSource_SidecarHasNoSecrets(t *testing.T) {
+	dir := t.TempDir()
+	password := "super-secret-password-12345"
+	src := NewMasterPasswordSource(dir, staticPrompt(password, password))
+
+	if _, err := src.GetEncryptionKey(); err != nil {
+		t.Fatal(err)
+	}
+
+	b, err := os.ReadFile(filepath.Join(dir, sidecarFileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if bytes.Contains(b, []byte(password)) {
+		t.Fatal("sidecar contains the master password in plaintext")
+	}
+}

--- a/internal/database/master_password_test.go
+++ b/internal/database/master_password_test.go
@@ -335,6 +335,64 @@ func TestMasterPasswordSource_ConcurrentFirstRunMultiProcess(t *testing.T) {
 	}
 }
 
+func TestMasterPasswordSource_StoreEncryptionKey_NoOp(t *testing.T) {
+	src := NewMasterPasswordSource(t.TempDir(), staticPrompt())
+	if err := src.StoreEncryptionKey([]byte("ignored")); err != nil {
+		t.Errorf("StoreEncryptionKey should be a no-op, got %v", err)
+	}
+}
+
+func TestMasterPasswordSource_RejectsShortSalt(t *testing.T) {
+	dir := t.TempDir()
+	bad := []byte(`{"version":1,"algorithm":"argon2id","salt":"AQID","verify":"","params":{"time":3,"memory":65536,"threads":4,"key_len":32}}`)
+	if err := os.WriteFile(filepath.Join(dir, sidecarFileName), bad, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	called := false
+	prompt := func(_ string) ([]byte, error) {
+		called = true
+		return []byte("password"), nil
+	}
+	src := NewMasterPasswordSource(dir, prompt)
+	_, err := src.GetEncryptionKey()
+	if err == nil || !bytes.Contains([]byte(err.Error()), []byte("salt too short")) {
+		t.Fatalf("expected salt-too-short error, got %v", err)
+	}
+	if called {
+		t.Errorf("prompt should not be called when sidecar fails sanity checks")
+	}
+}
+
+func TestMasterPasswordSource_RejectsShortVerify(t *testing.T) {
+	dir := t.TempDir()
+	saltB64 := "QUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUE="
+	bad := []byte(`{"version":1,"algorithm":"argon2id","salt":"` + saltB64 + `","verify":"AQID","params":{"time":3,"memory":65536,"threads":4,"key_len":32}}`)
+	if err := os.WriteFile(filepath.Join(dir, sidecarFileName), bad, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	called := false
+	prompt := func(_ string) ([]byte, error) {
+		called = true
+		return []byte("password"), nil
+	}
+	src := NewMasterPasswordSource(dir, prompt)
+	_, err := src.GetEncryptionKey()
+	if err == nil || !bytes.Contains([]byte(err.Error()), []byte("verify blob too short")) {
+		t.Fatalf("expected verify-too-short error, got %v", err)
+	}
+	if called {
+		t.Errorf("prompt should not be called when sidecar fails sanity checks")
+	}
+}
+
+func TestMasterPasswordSource_RejectsNonAbsoluteDataDir(t *testing.T) {
+	src := NewMasterPasswordSource("relative/path", staticPrompt("password-12345", "password-12345"))
+	_, err := src.GetEncryptionKey()
+	if err == nil || !bytes.Contains([]byte(err.Error()), []byte("must be an absolute path")) {
+		t.Fatalf("expected absolute-path error, got %v", err)
+	}
+}
+
 func TestMasterPasswordSource_SidecarHasNoSecrets(t *testing.T) {
 	dir := t.TempDir()
 	password := "super-secret-password-12345"

--- a/internal/database/master_password_test.go
+++ b/internal/database/master_password_test.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+
+	"github.com/bashhack/sesh/internal/secure"
 )
 
 func staticPrompt(passwords ...string) PasswordPromptFunc {
@@ -333,6 +335,33 @@ func TestMasterPasswordSource_ConcurrentFirstRunMultiProcess(t *testing.T) {
 			t.Fatalf("process %d derived a different key — flock did not serialize across processes\n  process 0: %s\n  process %d: %s", i, first, i, outs[i].String())
 		}
 	}
+}
+
+func TestMasterPasswordSource_ConcurrentGetAndCloseAreSafe(t *testing.T) {
+	dir := t.TempDir()
+	var prompt PasswordPromptFunc = func(_ string) ([]byte, error) {
+		return []byte("test-password-12345"), nil
+	}
+	src := NewMasterPasswordSource(dir, prompt)
+	if _, err := src.GetEncryptionKey(); err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			if k, err := src.GetEncryptionKey(); err == nil {
+				secure.SecureZeroBytes(k)
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			src.Close()
+		}()
+	}
+	wg.Wait()
 }
 
 func TestMasterPasswordSource_StoreEncryptionKey_NoOp(t *testing.T) {

--- a/internal/database/store.go
+++ b/internal/database/store.go
@@ -49,8 +49,12 @@ func Open(dbPath string, ks KeySource) (*Store, error) {
 	return &Store{db: db, keySource: ks}, nil
 }
 
-// Close releases the database connection.
+// Close releases the database connection and clears any cached key
+// material held by the key source.
 func (s *Store) Close() error {
+	if closer, ok := s.keySource.(interface{ Close() }); ok {
+		closer.Close()
+	}
 	return s.db.Close()
 }
 

--- a/internal/keychain/mocks/keychain_mock.go
+++ b/internal/keychain/mocks/keychain_mock.go
@@ -1,11 +1,19 @@
 // Package mocks provides test doubles for the keychain package interfaces.
 package mocks
 
-import "github.com/bashhack/sesh/internal/keychain"
+import (
+	"time"
+
+	"github.com/bashhack/sesh/internal/keychain"
+)
 
 // MockProvider is a mock implementation of the keychain.Provider interface.
 // Any *Func field left nil returns the zero value of its method's return
 // types so tests can wire only the subset of methods they care about.
+//
+// SetSecretAtFunc and SetDescriptionAtFunc are present so MockProvider can
+// stand in for a keychain.TimestampedStore in tests; if either is wired,
+// the mock satisfies the type assertion `provider.(keychain.TimestampedStore)`.
 type MockProvider struct {
 	GetSecretFunc         func(account, service string) ([]byte, error)
 	SetSecretFunc         func(account, service string, secret []byte) error
@@ -15,6 +23,8 @@ type MockProvider struct {
 	ListEntriesFunc       func(service string) ([]keychain.KeychainEntry, error)
 	DeleteEntryFunc       func(account, service string) error
 	SetDescriptionFunc    func(service, account, description string) error
+	SetSecretAtFunc       func(account, service string, secret []byte, createdAt, updatedAt time.Time) error
+	SetDescriptionAtFunc  func(service, account, description string, updatedAt time.Time) error
 }
 
 // GetSecret implements the keychain.Provider interface
@@ -79,4 +89,30 @@ func (m *MockProvider) SetDescription(service, account, description string) erro
 		return nil
 	}
 	return m.SetDescriptionFunc(service, account, description)
+}
+
+// SetSecretAt implements keychain.TimestampedStore. Falls back to the
+// non-timestamped SetSecretFunc when SetSecretAtFunc is unset so existing
+// tests that wire only SetSecretFunc continue to observe writes routed
+// through the timestamped path (e.g. via Migrate).
+func (m *MockProvider) SetSecretAt(account, service string, secret []byte, createdAt, updatedAt time.Time) error {
+	if m.SetSecretAtFunc != nil {
+		return m.SetSecretAtFunc(account, service, secret, createdAt, updatedAt)
+	}
+	if m.SetSecretFunc != nil {
+		return m.SetSecretFunc(account, service, secret)
+	}
+	return nil
+}
+
+// SetDescriptionAt implements keychain.TimestampedStore. Falls back to
+// SetDescriptionFunc when SetDescriptionAtFunc is unset.
+func (m *MockProvider) SetDescriptionAt(service, account, description string, updatedAt time.Time) error {
+	if m.SetDescriptionAtFunc != nil {
+		return m.SetDescriptionAtFunc(service, account, description, updatedAt)
+	}
+	if m.SetDescriptionFunc != nil {
+		return m.SetDescriptionFunc(service, account, description)
+	}
+	return nil
 }

--- a/internal/migration/migrate.go
+++ b/internal/migration/migrate.go
@@ -4,6 +4,7 @@ package migration
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/bashhack/sesh/internal/constants"
 	"github.com/bashhack/sesh/internal/keychain"
@@ -33,8 +34,12 @@ type Result struct {
 	Skipped  int
 }
 
-// PlanEntry describes a single entry that would be migrated.
+// PlanEntry describes a single entry that would be migrated. CreatedAt and
+// UpdatedAt come from the source's ListEntries; they may be zero for sources
+// that don't track timestamps (e.g. macOS Keychain).
 type PlanEntry struct {
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
 	Service     string
 	Account     string
 	Description string
@@ -60,6 +65,8 @@ func Plan(source keychain.Provider) ([]PlanEntry, error) {
 				Service:     e.Service,
 				Account:     e.Account,
 				Description: e.Description,
+				CreatedAt:   e.CreatedAt,
+				UpdatedAt:   e.UpdatedAt,
 			})
 		}
 	}
@@ -69,9 +76,16 @@ func Plan(source keychain.Provider) ([]PlanEntry, error) {
 
 // Migrate copies all sesh entries from source to dest.
 // Existing entries in dest are skipped (not overwritten).
+//
+// If dest implements keychain.TimestampedStore, the source's CreatedAt /
+// UpdatedAt are forwarded to SetSecretAt / SetDescriptionAt so audit history
+// survives the copy. Sources that don't track timestamps return zero values,
+// and the timestamped methods fall back to time.Now in that case — so this
+// path is a strict superset of the bare SetSecret behaviour.
 func Migrate(source, dest keychain.Provider) (Result, error) {
 	var result Result
 	seen := make(map[entryKey]bool)
+	ts, _ := dest.(keychain.TimestampedStore)
 
 	for _, prefix := range migratePrefixes {
 		entries, err := source.ListEntries(prefix)
@@ -108,15 +122,15 @@ func Migrate(source, dest keychain.Provider) (Result, error) {
 				continue
 			}
 
-			if err := dest.SetSecret(entry.Account, entry.Service, secret); err != nil {
-				result.Errors = append(result.Errors, fmt.Sprintf("%s: failed to write: %v", entry.Service, err))
+			if writeErr := writeEntry(dest, ts, &entry, secret); writeErr != nil {
+				result.Errors = append(result.Errors, fmt.Sprintf("%s: failed to write: %v", entry.Service, writeErr))
 				secure.SecureZeroBytes(secret)
 				continue
 			}
 			secure.SecureZeroBytes(secret)
 
 			if entry.Description != "" {
-				if descErr := dest.SetDescription(entry.Service, entry.Account, entry.Description); descErr != nil {
+				if descErr := writeDescription(dest, ts, &entry); descErr != nil {
 					result.Errors = append(result.Errors, fmt.Sprintf("%s: migrated but description failed: %v", entry.Service, descErr))
 				}
 			}
@@ -126,4 +140,18 @@ func Migrate(source, dest keychain.Provider) (Result, error) {
 	}
 
 	return result, nil
+}
+
+func writeEntry(dest keychain.Provider, ts keychain.TimestampedStore, entry *keychain.KeychainEntry, secret []byte) error {
+	if ts != nil {
+		return ts.SetSecretAt(entry.Account, entry.Service, secret, entry.CreatedAt, entry.UpdatedAt)
+	}
+	return dest.SetSecret(entry.Account, entry.Service, secret)
+}
+
+func writeDescription(dest keychain.Provider, ts keychain.TimestampedStore, entry *keychain.KeychainEntry) error {
+	if ts != nil {
+		return ts.SetDescriptionAt(entry.Service, entry.Account, entry.Description, entry.UpdatedAt)
+	}
+	return dest.SetDescription(entry.Service, entry.Account, entry.Description)
 }

--- a/internal/migration/migrate_test.go
+++ b/internal/migration/migrate_test.go
@@ -323,6 +323,54 @@ func TestMigratePreservesTimestampsWhenDestSupportsThem(t *testing.T) {
 	}
 }
 
+func TestMigrateForwardsZeroTimestampsWhenDestSupportsThem(t *testing.T) {
+	source := &mocks.MockProvider{
+		ListEntriesFunc: func(prefix string) ([]keychain.KeychainEntry, error) {
+			if prefix != "sesh-totp" {
+				return nil, nil
+			}
+			return []keychain.KeychainEntry{{
+				Service:     "sesh-totp/github",
+				Account:     "alice",
+				Description: "TOTP for GitHub",
+			}}, nil
+		},
+		GetSecretFunc: func(_, _ string) ([]byte, error) {
+			return []byte("totp-secret"), nil
+		},
+	}
+
+	var gotCreated, gotUpdated, gotDescUpdated time.Time
+	dest := &mocks.MockProvider{
+		GetSecretFunc: func(_, _ string) ([]byte, error) { return nil, keychain.ErrNotFound },
+		SetSecretAtFunc: func(_, _ string, _ []byte, c, u time.Time) error {
+			gotCreated, gotUpdated = c, u
+			return nil
+		},
+		SetDescriptionAtFunc: func(_, _, _ string, u time.Time) error {
+			gotDescUpdated = u
+			return nil
+		},
+	}
+
+	result, err := Migrate(source, dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Migrated != 1 {
+		t.Fatalf("Migrated = %d, want 1", result.Migrated)
+	}
+	if !gotCreated.IsZero() {
+		t.Errorf("CreatedAt forwarded = %v, want zero (so dest.SetSecretAt can fall back to time.Now)", gotCreated)
+	}
+	if !gotUpdated.IsZero() {
+		t.Errorf("UpdatedAt forwarded = %v, want zero", gotUpdated)
+	}
+	if !gotDescUpdated.IsZero() {
+		t.Errorf("UpdatedAt forwarded to SetDescriptionAt = %v, want zero", gotDescUpdated)
+	}
+}
+
 // bareDest implements keychain.Provider but explicitly NOT
 // keychain.TimestampedStore — used to exercise Migrate's fallback path.
 type bareDest struct {

--- a/internal/migration/migrate_test.go
+++ b/internal/migration/migrate_test.go
@@ -323,6 +323,70 @@ func TestMigratePreservesTimestampsWhenDestSupportsThem(t *testing.T) {
 	}
 }
 
+// bareDest implements keychain.Provider but explicitly NOT
+// keychain.TimestampedStore — used to exercise Migrate's fallback path.
+type bareDest struct {
+	lastDescription  string
+	setSecretCalls   int
+	descriptionCalls int
+}
+
+func (d *bareDest) GetSecret(_, _ string) ([]byte, error) {
+	return nil, keychain.ErrNotFound
+}
+
+func (d *bareDest) SetSecret(_, _ string, _ []byte) error {
+	d.setSecretCalls++
+	return nil
+}
+
+func (d *bareDest) GetSecretString(_, _ string) (string, error)            { return "", nil }
+func (d *bareDest) SetSecretString(_, _, _ string) error                   { return nil }
+func (d *bareDest) GetMFASerialBytes(_, _ string) ([]byte, error)          { return nil, keychain.ErrNotFound }
+func (d *bareDest) ListEntries(_ string) ([]keychain.KeychainEntry, error) { return nil, nil }
+func (d *bareDest) DeleteEntry(_, _ string) error                          { return nil }
+func (d *bareDest) SetDescription(_, _, description string) error {
+	d.descriptionCalls++
+	d.lastDescription = description
+	return nil
+}
+
+func TestMigrateFallsBackToBareSetSecretWhenDestNotTimestamped(t *testing.T) {
+	source := &mocks.MockProvider{
+		ListEntriesFunc: func(prefix string) ([]keychain.KeychainEntry, error) {
+			if prefix != "sesh-totp" {
+				return nil, nil
+			}
+			return []keychain.KeychainEntry{{
+				Service:     "sesh-totp/github",
+				Account:     "alice",
+				Description: "TOTP",
+				CreatedAt:   time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+				UpdatedAt:   time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC),
+			}}, nil
+		},
+		GetSecretFunc: func(_, _ string) ([]byte, error) { return []byte("s"), nil },
+	}
+
+	dest := &bareDest{}
+	result, err := Migrate(source, dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Migrated != 1 {
+		t.Fatalf("Migrated = %d, want 1", result.Migrated)
+	}
+	if dest.setSecretCalls != 1 {
+		t.Errorf("SetSecret calls = %d, want 1 (fallback path)", dest.setSecretCalls)
+	}
+	if dest.descriptionCalls != 1 {
+		t.Errorf("SetDescription calls = %d, want 1", dest.descriptionCalls)
+	}
+	if dest.lastDescription != "TOTP" {
+		t.Errorf("description = %q, want TOTP", dest.lastDescription)
+	}
+}
+
 func TestMigrateEmpty(t *testing.T) {
 	source := newEntryStore()
 	dest := newEntryStore()

--- a/internal/migration/migrate_test.go
+++ b/internal/migration/migrate_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/bashhack/sesh/internal/keychain"
 	"github.com/bashhack/sesh/internal/keychain/mocks"
@@ -266,6 +267,59 @@ func TestMigrateDedupesOverlappingPrefixes(t *testing.T) {
 	}
 	if setCount != 2 {
 		t.Errorf("SetSecret call count = %d, want 2", setCount)
+	}
+}
+
+func TestMigratePreservesTimestampsWhenDestSupportsThem(t *testing.T) {
+	createdAt := time.Date(2024, 3, 15, 10, 30, 0, 0, time.UTC)
+	updatedAt := time.Date(2025, 1, 20, 14, 0, 0, 0, time.UTC)
+
+	source := &mocks.MockProvider{
+		ListEntriesFunc: func(prefix string) ([]keychain.KeychainEntry, error) {
+			if prefix != "sesh-totp" {
+				return nil, nil
+			}
+			return []keychain.KeychainEntry{{
+				Service:     "sesh-totp/github",
+				Account:     "alice",
+				Description: "TOTP for GitHub",
+				CreatedAt:   createdAt,
+				UpdatedAt:   updatedAt,
+			}}, nil
+		},
+		GetSecretFunc: func(_, _ string) ([]byte, error) {
+			return []byte("totp-secret"), nil
+		},
+	}
+
+	var gotCreated, gotUpdated, gotDescUpdated time.Time
+	dest := &mocks.MockProvider{
+		GetSecretFunc: func(_, _ string) ([]byte, error) { return nil, keychain.ErrNotFound },
+		SetSecretAtFunc: func(_, _ string, _ []byte, c, u time.Time) error {
+			gotCreated, gotUpdated = c, u
+			return nil
+		},
+		SetDescriptionAtFunc: func(_, _, _ string, u time.Time) error {
+			gotDescUpdated = u
+			return nil
+		},
+	}
+
+	result, err := Migrate(source, dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Migrated != 1 {
+		t.Fatalf("Migrated = %d, want 1", result.Migrated)
+	}
+	if !gotCreated.Equal(createdAt) {
+		t.Errorf("CreatedAt = %v, want %v", gotCreated, createdAt)
+	}
+	if !gotUpdated.Equal(updatedAt) {
+		t.Errorf("UpdatedAt on SetSecretAt = %v, want %v", gotUpdated, updatedAt)
+	}
+	if !gotDescUpdated.Equal(updatedAt) {
+		t.Errorf("UpdatedAt on SetDescriptionAt = %v, want %v", gotDescUpdated, updatedAt)
 	}
 }
 

--- a/internal/password/export_encrypted.go
+++ b/internal/password/export_encrypted.go
@@ -35,6 +35,31 @@ func defaultEncryptedExportParams() encryptedExportParams {
 	}
 }
 
+// validateEncryptedExportParams bounds-checks Argon2id parameters from an
+// untrusted envelope. Without these checks a malicious file could OOM the
+// user via a huge Memory value, stall the CPU via a huge Time, or trigger
+// a panic via Threads=0.
+func validateEncryptedExportParams(p encryptedExportParams) error {
+	const (
+		maxMemoryKiB = 1 << 20 // 1 GiB
+		maxTime      = 10
+		maxThreads   = 16
+	)
+	if p.Memory == 0 || p.Memory > maxMemoryKiB {
+		return fmt.Errorf("envelope memory param out of range: %d KiB (max %d)", p.Memory, maxMemoryKiB)
+	}
+	if p.Time == 0 || p.Time > maxTime {
+		return fmt.Errorf("envelope time param out of range: %d (max %d)", p.Time, maxTime)
+	}
+	if p.Threads == 0 || p.Threads > maxThreads {
+		return fmt.Errorf("envelope threads param out of range: %d (max %d)", p.Threads, maxThreads)
+	}
+	if p.KeyLen != 32 {
+		return fmt.Errorf("envelope key_len must be 32, got %d", p.KeyLen)
+	}
+	return nil
+}
+
 // EncryptedEnvelope is the on-disk format for a password-encrypted export.
 // salt + params are public (needed to re-derive the key); ciphertext is the
 // AES-256-GCM output of the JSON-serialized entries.
@@ -63,7 +88,6 @@ func (m *Manager) ExportEncrypted(w io.Writer, opts ExportOptions, password []by
 	if err != nil {
 		return 0, err
 	}
-	defer secure.SecureZeroBytes(buf.Bytes())
 
 	salt := make([]byte, 32)
 	if _, err := io.ReadFull(rand.Reader, salt); err != nil {
@@ -74,7 +98,9 @@ func (m *Manager) ExportEncrypted(w io.Writer, opts ExportOptions, password []by
 	key := argon2.IDKey(password, salt, params.Time, params.Memory, params.Threads, params.KeyLen)
 	defer secure.SecureZeroBytes(key)
 
-	ciphertext, err := gcmSeal(key, buf.Bytes())
+	plaintext := buf.Bytes()
+	ciphertext, err := gcmSeal(key, plaintext)
+	secure.SecureZeroBytes(plaintext)
 	if err != nil {
 		return 0, fmt.Errorf("encrypt payload: %w", err)
 	}
@@ -108,6 +134,12 @@ func (m *Manager) ImportEncrypted(r io.Reader, opts ImportOptions, password []by
 
 	if envelope.Version != encryptedExportVersion {
 		return ImportResult{}, fmt.Errorf("unsupported envelope version %d (expected %d)", envelope.Version, encryptedExportVersion)
+	}
+	if envelope.Algorithm != "argon2id" {
+		return ImportResult{}, fmt.Errorf("unsupported algorithm %q", envelope.Algorithm)
+	}
+	if err := validateEncryptedExportParams(envelope.Params); err != nil {
+		return ImportResult{}, err
 	}
 
 	salt, err := base64.StdEncoding.DecodeString(envelope.Salt)

--- a/internal/password/export_encrypted.go
+++ b/internal/password/export_encrypted.go
@@ -146,6 +146,9 @@ func (m *Manager) ImportEncrypted(r io.Reader, opts ImportOptions, password []by
 	if err != nil {
 		return ImportResult{}, fmt.Errorf("decode salt: %w", err)
 	}
+	if len(salt) < 16 {
+		return ImportResult{}, fmt.Errorf("envelope salt too short: %d bytes (min 16)", len(salt))
+	}
 
 	ciphertext, err := base64.StdEncoding.DecodeString(envelope.Ciphertext)
 	if err != nil {

--- a/internal/password/export_encrypted.go
+++ b/internal/password/export_encrypted.go
@@ -160,6 +160,10 @@ func (m *Manager) ImportEncrypted(r io.Reader, opts ImportOptions, password []by
 	if err != nil {
 		return ImportResult{}, fmt.Errorf("wrong password or corrupted export: %w", err)
 	}
+	// Zeroes the JSON envelope buffer once Import returns, but the parsed
+	// entry secrets land in immutable Go strings inside the unmarshalled
+	// structs and outlive this defer — same caveat as elsewhere in the
+	// codebase. See internal/secure/memory.go for the broader context.
 	defer secure.SecureZeroBytes(payload)
 
 	forwardOpts := opts

--- a/internal/password/export_encrypted.go
+++ b/internal/password/export_encrypted.go
@@ -1,0 +1,169 @@
+package password
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"golang.org/x/crypto/argon2"
+
+	"github.com/bashhack/sesh/internal/secure"
+)
+
+const encryptedExportVersion = 1
+
+// encryptedExportParams holds Argon2id tuning for the encrypted export envelope.
+// Kept local to avoid importing the database package (import cycle).
+type encryptedExportParams struct {
+	Time    uint32 `json:"time"`
+	Memory  uint32 `json:"memory"`
+	Threads uint8  `json:"threads"`
+	KeyLen  uint32 `json:"key_len"`
+}
+
+func defaultEncryptedExportParams() encryptedExportParams {
+	return encryptedExportParams{
+		Time:    3,
+		Memory:  64 * 1024,
+		Threads: 4,
+		KeyLen:  32,
+	}
+}
+
+// EncryptedEnvelope is the on-disk format for a password-encrypted export.
+// salt + params are public (needed to re-derive the key); ciphertext is the
+// AES-256-GCM output of the JSON-serialized entries.
+type EncryptedEnvelope struct {
+	Algorithm  string                `json:"algorithm"`
+	Salt       string                `json:"salt"`       // base64
+	Ciphertext string                `json:"ciphertext"` // base64
+	Params     encryptedExportParams `json:"params"`
+	Version    int                   `json:"version"`
+}
+
+// ExportEncrypted writes a password-encrypted export to w.
+// The password is used to derive a key via Argon2id; the derived key
+// encrypts the JSON payload with AES-256-GCM. The output is portable —
+// anyone with the password can decrypt it, regardless of key source.
+func (m *Manager) ExportEncrypted(w io.Writer, opts ExportOptions, password []byte) (int, error) {
+	if len(password) == 0 {
+		return 0, fmt.Errorf("password cannot be empty")
+	}
+
+	var buf bytes.Buffer
+	count, err := m.Export(&buf, ExportOptions{
+		Format:    FormatJSON,
+		EntryType: opts.EntryType,
+	})
+	if err != nil {
+		return 0, err
+	}
+	defer secure.SecureZeroBytes(buf.Bytes())
+
+	salt := make([]byte, 32)
+	if _, err := io.ReadFull(rand.Reader, salt); err != nil {
+		return 0, fmt.Errorf("generate salt: %w", err)
+	}
+
+	params := defaultEncryptedExportParams()
+	key := argon2.IDKey(password, salt, params.Time, params.Memory, params.Threads, params.KeyLen)
+	defer secure.SecureZeroBytes(key)
+
+	ciphertext, err := gcmSeal(key, buf.Bytes())
+	if err != nil {
+		return 0, fmt.Errorf("encrypt payload: %w", err)
+	}
+
+	envelope := EncryptedEnvelope{
+		Version:    encryptedExportVersion,
+		Algorithm:  "argon2id",
+		Salt:       base64.StdEncoding.EncodeToString(salt),
+		Params:     params,
+		Ciphertext: base64.StdEncoding.EncodeToString(ciphertext),
+	}
+
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(envelope); err != nil {
+		return 0, fmt.Errorf("write envelope: %w", err)
+	}
+	return count, nil
+}
+
+// ImportEncrypted reads a password-encrypted export from r and imports it.
+func (m *Manager) ImportEncrypted(r io.Reader, opts ImportOptions, password []byte) (ImportResult, error) {
+	if len(password) == 0 {
+		return ImportResult{}, fmt.Errorf("password cannot be empty")
+	}
+
+	var envelope EncryptedEnvelope
+	if err := json.NewDecoder(r).Decode(&envelope); err != nil {
+		return ImportResult{}, fmt.Errorf("read envelope: %w", err)
+	}
+
+	if envelope.Version != encryptedExportVersion {
+		return ImportResult{}, fmt.Errorf("unsupported envelope version %d (expected %d)", envelope.Version, encryptedExportVersion)
+	}
+
+	salt, err := base64.StdEncoding.DecodeString(envelope.Salt)
+	if err != nil {
+		return ImportResult{}, fmt.Errorf("decode salt: %w", err)
+	}
+
+	ciphertext, err := base64.StdEncoding.DecodeString(envelope.Ciphertext)
+	if err != nil {
+		return ImportResult{}, fmt.Errorf("decode ciphertext: %w", err)
+	}
+
+	p := envelope.Params
+	key := argon2.IDKey(password, salt, p.Time, p.Memory, p.Threads, p.KeyLen)
+	defer secure.SecureZeroBytes(key)
+
+	payload, err := gcmOpen(key, ciphertext)
+	if err != nil {
+		return ImportResult{}, fmt.Errorf("wrong password or corrupted export: %w", err)
+	}
+	defer secure.SecureZeroBytes(payload)
+
+	forwardOpts := opts
+	forwardOpts.Format = FormatJSON
+	return m.Import(bytes.NewReader(payload), forwardOpts)
+}
+
+// gcmSeal returns nonce || ciphertext || tag.
+func gcmSeal(key, plaintext []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, err
+	}
+	return gcm.Seal(nonce, nonce, plaintext, nil), nil
+}
+
+func gcmOpen(key, ciphertext []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	if len(ciphertext) < gcm.NonceSize() {
+		return nil, fmt.Errorf("ciphertext too short")
+	}
+	nonce, enc := ciphertext[:gcm.NonceSize()], ciphertext[gcm.NonceSize():]
+	return gcm.Open(nil, nonce, enc, nil)
+}

--- a/internal/password/export_encrypted_test.go
+++ b/internal/password/export_encrypted_test.go
@@ -145,6 +145,9 @@ func TestImportEncrypted_UnsupportedVersion(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for unsupported version")
 	}
+	if !strings.Contains(err.Error(), "version") {
+		t.Errorf("error %q does not mention version — may have failed an unrelated check", err.Error())
+	}
 }
 
 func TestImportEncrypted_UnsupportedAlgorithm(t *testing.T) {
@@ -153,6 +156,9 @@ func TestImportEncrypted_UnsupportedAlgorithm(t *testing.T) {
 	_, err := mgr.ImportEncrypted(bytes.NewReader(data), ImportOptions{}, []byte("any"))
 	if err == nil {
 		t.Fatal("expected error for unsupported algorithm")
+	}
+	if !strings.Contains(err.Error(), "algorithm") {
+		t.Errorf("error %q does not mention algorithm — may have failed an unrelated check", err.Error())
 	}
 }
 

--- a/internal/password/export_encrypted_test.go
+++ b/internal/password/export_encrypted_test.go
@@ -138,3 +138,58 @@ func TestImportEncrypted_UnsupportedVersion(t *testing.T) {
 		t.Fatal("expected error for unsupported version")
 	}
 }
+
+func TestImportEncrypted_UnsupportedAlgorithm(t *testing.T) {
+	mgr := newEncryptedTestManager(t)
+	data := []byte(`{"version": 1, "algorithm": "scrypt", "salt": "", "params": {"time":3,"memory":65536,"threads":4,"key_len":32}, "ciphertext": ""}`)
+	_, err := mgr.ImportEncrypted(bytes.NewReader(data), ImportOptions{}, []byte("any"))
+	if err == nil {
+		t.Fatal("expected error for unsupported algorithm")
+	}
+}
+
+func TestImportEncrypted_RejectsOutOfRangeParams(t *testing.T) {
+	cases := map[string]string{
+		"zero memory":   `{"version":1,"algorithm":"argon2id","salt":"","ciphertext":"","params":{"time":3,"memory":0,"threads":4,"key_len":32}}`,
+		"huge memory":   `{"version":1,"algorithm":"argon2id","salt":"","ciphertext":"","params":{"time":3,"memory":2147483647,"threads":4,"key_len":32}}`,
+		"zero time":     `{"version":1,"algorithm":"argon2id","salt":"","ciphertext":"","params":{"time":0,"memory":65536,"threads":4,"key_len":32}}`,
+		"huge time":     `{"version":1,"algorithm":"argon2id","salt":"","ciphertext":"","params":{"time":999,"memory":65536,"threads":4,"key_len":32}}`,
+		"zero threads":  `{"version":1,"algorithm":"argon2id","salt":"","ciphertext":"","params":{"time":3,"memory":65536,"threads":0,"key_len":32}}`,
+		"huge threads":  `{"version":1,"algorithm":"argon2id","salt":"","ciphertext":"","params":{"time":3,"memory":65536,"threads":99,"key_len":32}}`,
+		"wrong key_len": `{"version":1,"algorithm":"argon2id","salt":"","ciphertext":"","params":{"time":3,"memory":65536,"threads":4,"key_len":16}}`,
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			mgr := newEncryptedTestManager(t)
+			_, err := mgr.ImportEncrypted(bytes.NewReader([]byte(body)), ImportOptions{}, []byte("any"))
+			if err == nil {
+				t.Fatal("expected error for out-of-range params")
+			}
+		})
+	}
+}
+
+func TestImportEncrypted_MalformedSaltOrCiphertext(t *testing.T) {
+	cases := map[string]string{
+		"bad salt base64":       `{"version":1,"algorithm":"argon2id","salt":"!!!","ciphertext":"","params":{"time":3,"memory":65536,"threads":4,"key_len":32}}`,
+		"bad ciphertext base64": `{"version":1,"algorithm":"argon2id","salt":"","ciphertext":"!!!","params":{"time":3,"memory":65536,"threads":4,"key_len":32}}`,
+		"short ciphertext":      `{"version":1,"algorithm":"argon2id","salt":"","ciphertext":"AAA=","params":{"time":3,"memory":65536,"threads":4,"key_len":32}}`,
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			mgr := newEncryptedTestManager(t)
+			_, err := mgr.ImportEncrypted(bytes.NewReader([]byte(body)), ImportOptions{}, []byte("password"))
+			if err == nil {
+				t.Fatal("expected error for malformed envelope")
+			}
+		})
+	}
+}
+
+func TestImportEncrypted_BadJSON(t *testing.T) {
+	mgr := newEncryptedTestManager(t)
+	_, err := mgr.ImportEncrypted(bytes.NewReader([]byte("not json")), ImportOptions{}, []byte("any"))
+	if err == nil {
+		t.Fatal("expected error for malformed JSON envelope")
+	}
+}

--- a/internal/password/export_encrypted_test.go
+++ b/internal/password/export_encrypted_test.go
@@ -1,0 +1,140 @@
+package password
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/bashhack/sesh/internal/keychain"
+	"github.com/bashhack/sesh/internal/keychain/mocks"
+)
+
+func newEncryptedTestManager(t *testing.T) *Manager {
+	t.Helper()
+	data := map[string][]byte{}
+	desc := map[string]string{}
+	kc := &mocks.MockProvider{
+		GetSecretFunc: func(account, service string) ([]byte, error) {
+			v, ok := data[service]
+			if !ok {
+				return nil, keychain.ErrNotFound
+			}
+			cp := make([]byte, len(v))
+			copy(cp, v)
+			return cp, nil
+		},
+		SetSecretFunc: func(account, service string, secret []byte) error {
+			cp := make([]byte, len(secret))
+			copy(cp, secret)
+			data[service] = cp
+			return nil
+		},
+		DeleteEntryFunc: func(account, service string) error {
+			delete(data, service)
+			return nil
+		},
+		SetDescriptionFunc: func(service, account, description string) error {
+			desc[service] = description
+			return nil
+		},
+		ListEntriesFunc: func(prefix string) ([]keychain.KeychainEntry, error) {
+			var entries []keychain.KeychainEntry
+			for svc := range data {
+				if strings.HasPrefix(svc, prefix) {
+					entries = append(entries, keychain.KeychainEntry{Service: svc, Account: "testuser", Description: desc[svc]})
+				}
+			}
+			return entries, nil
+		},
+	}
+	return NewManager(kc, "testuser")
+}
+
+func TestExportImportEncrypted_RoundTrip(t *testing.T) {
+	mgr := newEncryptedTestManager(t)
+
+	if err := mgr.StorePasswordString("github", "alice", "gh-secret", EntryTypePassword); err != nil {
+		t.Fatal(err)
+	}
+	if err := mgr.StorePasswordString("stripe", "admin", "sk_live_abc", EntryTypeAPIKey); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	password := []byte("my-export-password")
+	count, err := mgr.ExportEncrypted(&buf, ExportOptions{}, password)
+	if err != nil {
+		t.Fatalf("ExportEncrypted: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("expected 2 exported, got %d", count)
+	}
+
+	plaintextSecrets := []string{"gh-secret", "sk_live_abc"}
+	for _, s := range plaintextSecrets {
+		if bytes.Contains(buf.Bytes(), []byte(s)) {
+			t.Fatalf("encrypted export contains plaintext secret %q", s)
+		}
+	}
+
+	mgr2 := newEncryptedTestManager(t)
+	result, err := mgr2.ImportEncrypted(&buf, ImportOptions{}, password)
+	if err != nil {
+		t.Fatalf("ImportEncrypted: %v", err)
+	}
+	if result.Imported != 2 {
+		t.Fatalf("expected 2 imported, got %d (errors: %v)", result.Imported, result.Errors)
+	}
+
+	got, err := mgr2.GetPasswordString("github", "alice", EntryTypePassword)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "gh-secret" {
+		t.Fatalf("expected 'gh-secret', got %q", got)
+	}
+}
+
+func TestImportEncrypted_WrongPassword(t *testing.T) {
+	mgr := newEncryptedTestManager(t)
+	if err := mgr.StorePasswordString("github", "alice", "secret", EntryTypePassword); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if _, err := mgr.ExportEncrypted(&buf, ExportOptions{}, []byte("correct-password")); err != nil {
+		t.Fatal(err)
+	}
+
+	mgr2 := newEncryptedTestManager(t)
+	_, err := mgr2.ImportEncrypted(&buf, ImportOptions{}, []byte("wrong-password"))
+	if err == nil {
+		t.Fatal("expected error for wrong password")
+	}
+}
+
+func TestExportEncrypted_EmptyPassword(t *testing.T) {
+	mgr := newEncryptedTestManager(t)
+	var buf bytes.Buffer
+	_, err := mgr.ExportEncrypted(&buf, ExportOptions{}, nil)
+	if err == nil {
+		t.Fatal("expected error for empty password")
+	}
+}
+
+func TestImportEncrypted_EmptyPassword(t *testing.T) {
+	mgr := newEncryptedTestManager(t)
+	_, err := mgr.ImportEncrypted(bytes.NewReader([]byte("{}")), ImportOptions{}, nil)
+	if err == nil {
+		t.Fatal("expected error for empty password")
+	}
+}
+
+func TestImportEncrypted_UnsupportedVersion(t *testing.T) {
+	mgr := newEncryptedTestManager(t)
+	data := []byte(`{"version": 99, "algorithm": "argon2id", "salt": "", "params": {}, "ciphertext": ""}`)
+	_, err := mgr.ImportEncrypted(bytes.NewReader(data), ImportOptions{}, []byte("any"))
+	if err == nil {
+		t.Fatal("expected error for unsupported version")
+	}
+}

--- a/internal/password/export_encrypted_test.go
+++ b/internal/password/export_encrypted_test.go
@@ -93,6 +93,14 @@ func TestExportImportEncrypted_RoundTrip(t *testing.T) {
 	if got != "gh-secret" {
 		t.Fatalf("expected 'gh-secret', got %q", got)
 	}
+
+	gotAPI, err := mgr2.GetPasswordString("stripe", "admin", EntryTypeAPIKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotAPI != "sk_live_abc" {
+		t.Fatalf("expected 'sk_live_abc', got %q", gotAPI)
+	}
 }
 
 func TestImportEncrypted_WrongPassword(t *testing.T) {

--- a/internal/password/export_encrypted_test.go
+++ b/internal/password/export_encrypted_test.go
@@ -119,6 +119,9 @@ func TestImportEncrypted_WrongPassword(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for wrong password")
 	}
+	if !strings.Contains(err.Error(), "wrong password or corrupted") {
+		t.Errorf("error %q does not mention wrong password — may have failed an unrelated check", err.Error())
+	}
 }
 
 func TestExportEncrypted_EmptyPassword(t *testing.T) {
@@ -192,18 +195,25 @@ func TestImportEncrypted_RejectsOutOfRangeParams(t *testing.T) {
 
 func TestImportEncrypted_MalformedSaltOrCiphertext(t *testing.T) {
 	const validSalt = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" // 32 zero bytes
-	cases := map[string]string{
-		"bad salt base64":       `{"version":1,"algorithm":"argon2id","salt":"!!!","ciphertext":"","params":{"time":3,"memory":65536,"threads":4,"key_len":32}}`,
-		"short salt":            `{"version":1,"algorithm":"argon2id","salt":"AAA=","ciphertext":"","params":{"time":3,"memory":65536,"threads":4,"key_len":32}}`,
-		"bad ciphertext base64": `{"version":1,"algorithm":"argon2id","salt":"` + validSalt + `","ciphertext":"!!!","params":{"time":3,"memory":65536,"threads":4,"key_len":32}}`,
-		"short ciphertext":      `{"version":1,"algorithm":"argon2id","salt":"` + validSalt + `","ciphertext":"AAA=","params":{"time":3,"memory":65536,"threads":4,"key_len":32}}`,
+	cases := []struct {
+		name    string
+		body    string
+		wantSub string
+	}{
+		{"bad salt base64", `{"version":1,"algorithm":"argon2id","salt":"!!!","ciphertext":"","params":{"time":3,"memory":65536,"threads":4,"key_len":32}}`, "decode salt"},
+		{"short salt", `{"version":1,"algorithm":"argon2id","salt":"AAA=","ciphertext":"","params":{"time":3,"memory":65536,"threads":4,"key_len":32}}`, "salt too short"},
+		{"bad ciphertext base64", `{"version":1,"algorithm":"argon2id","salt":"` + validSalt + `","ciphertext":"!!!","params":{"time":3,"memory":65536,"threads":4,"key_len":32}}`, "decode ciphertext"},
+		{"short ciphertext", `{"version":1,"algorithm":"argon2id","salt":"` + validSalt + `","ciphertext":"AAA=","params":{"time":3,"memory":65536,"threads":4,"key_len":32}}`, "wrong password or corrupted"},
 	}
-	for name, body := range cases {
-		t.Run(name, func(t *testing.T) {
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
 			mgr := newEncryptedTestManager(t)
-			_, err := mgr.ImportEncrypted(bytes.NewReader([]byte(body)), ImportOptions{}, []byte("password"))
+			_, err := mgr.ImportEncrypted(bytes.NewReader([]byte(tc.body)), ImportOptions{}, []byte("password"))
 			if err == nil {
 				t.Fatal("expected error for malformed envelope")
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("error %q does not mention %q — may have failed an unrelated check", err.Error(), tc.wantSub)
 			}
 		})
 	}

--- a/internal/password/export_encrypted_test.go
+++ b/internal/password/export_encrypted_test.go
@@ -157,21 +157,28 @@ func TestImportEncrypted_UnsupportedAlgorithm(t *testing.T) {
 }
 
 func TestImportEncrypted_RejectsOutOfRangeParams(t *testing.T) {
-	cases := map[string]string{
-		"zero memory":   `{"version":1,"algorithm":"argon2id","salt":"","ciphertext":"","params":{"time":3,"memory":0,"threads":4,"key_len":32}}`,
-		"huge memory":   `{"version":1,"algorithm":"argon2id","salt":"","ciphertext":"","params":{"time":3,"memory":2147483647,"threads":4,"key_len":32}}`,
-		"zero time":     `{"version":1,"algorithm":"argon2id","salt":"","ciphertext":"","params":{"time":0,"memory":65536,"threads":4,"key_len":32}}`,
-		"huge time":     `{"version":1,"algorithm":"argon2id","salt":"","ciphertext":"","params":{"time":999,"memory":65536,"threads":4,"key_len":32}}`,
-		"zero threads":  `{"version":1,"algorithm":"argon2id","salt":"","ciphertext":"","params":{"time":3,"memory":65536,"threads":0,"key_len":32}}`,
-		"huge threads":  `{"version":1,"algorithm":"argon2id","salt":"","ciphertext":"","params":{"time":3,"memory":65536,"threads":99,"key_len":32}}`,
-		"wrong key_len": `{"version":1,"algorithm":"argon2id","salt":"","ciphertext":"","params":{"time":3,"memory":65536,"threads":4,"key_len":16}}`,
+	cases := []struct {
+		name    string
+		body    string
+		wantSub string // substring the param-validation error must contain
+	}{
+		{"zero memory", `{"version":1,"algorithm":"argon2id","salt":"","ciphertext":"","params":{"time":3,"memory":0,"threads":4,"key_len":32}}`, "memory"},
+		{"huge memory", `{"version":1,"algorithm":"argon2id","salt":"","ciphertext":"","params":{"time":3,"memory":2147483647,"threads":4,"key_len":32}}`, "memory"},
+		{"zero time", `{"version":1,"algorithm":"argon2id","salt":"","ciphertext":"","params":{"time":0,"memory":65536,"threads":4,"key_len":32}}`, "time"},
+		{"huge time", `{"version":1,"algorithm":"argon2id","salt":"","ciphertext":"","params":{"time":999,"memory":65536,"threads":4,"key_len":32}}`, "time"},
+		{"zero threads", `{"version":1,"algorithm":"argon2id","salt":"","ciphertext":"","params":{"time":3,"memory":65536,"threads":0,"key_len":32}}`, "threads"},
+		{"huge threads", `{"version":1,"algorithm":"argon2id","salt":"","ciphertext":"","params":{"time":3,"memory":65536,"threads":99,"key_len":32}}`, "threads"},
+		{"wrong key_len", `{"version":1,"algorithm":"argon2id","salt":"","ciphertext":"","params":{"time":3,"memory":65536,"threads":4,"key_len":16}}`, "key_len"},
 	}
-	for name, body := range cases {
-		t.Run(name, func(t *testing.T) {
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
 			mgr := newEncryptedTestManager(t)
-			_, err := mgr.ImportEncrypted(bytes.NewReader([]byte(body)), ImportOptions{}, []byte("any"))
+			_, err := mgr.ImportEncrypted(bytes.NewReader([]byte(tc.body)), ImportOptions{}, []byte("any"))
 			if err == nil {
 				t.Fatal("expected error for out-of-range params")
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("error %q does not mention %q — may have failed an unrelated check", err.Error(), tc.wantSub)
 			}
 		})
 	}

--- a/internal/password/export_encrypted_test.go
+++ b/internal/password/export_encrypted_test.go
@@ -170,10 +170,12 @@ func TestImportEncrypted_RejectsOutOfRangeParams(t *testing.T) {
 }
 
 func TestImportEncrypted_MalformedSaltOrCiphertext(t *testing.T) {
+	const validSalt = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" // 32 zero bytes
 	cases := map[string]string{
 		"bad salt base64":       `{"version":1,"algorithm":"argon2id","salt":"!!!","ciphertext":"","params":{"time":3,"memory":65536,"threads":4,"key_len":32}}`,
-		"bad ciphertext base64": `{"version":1,"algorithm":"argon2id","salt":"","ciphertext":"!!!","params":{"time":3,"memory":65536,"threads":4,"key_len":32}}`,
-		"short ciphertext":      `{"version":1,"algorithm":"argon2id","salt":"","ciphertext":"AAA=","params":{"time":3,"memory":65536,"threads":4,"key_len":32}}`,
+		"short salt":            `{"version":1,"algorithm":"argon2id","salt":"AAA=","ciphertext":"","params":{"time":3,"memory":65536,"threads":4,"key_len":32}}`,
+		"bad ciphertext base64": `{"version":1,"algorithm":"argon2id","salt":"` + validSalt + `","ciphertext":"!!!","params":{"time":3,"memory":65536,"threads":4,"key_len":32}}`,
+		"short ciphertext":      `{"version":1,"algorithm":"argon2id","salt":"` + validSalt + `","ciphertext":"AAA=","params":{"time":3,"memory":65536,"threads":4,"key_len":32}}`,
 	}
 	for name, body := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/internal/provider/password/provider.go
+++ b/internal/provider/password/provider.go
@@ -3,6 +3,7 @@ package password
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -155,8 +156,8 @@ func (p *Provider) ValidateRequest() error {
 		if p.format == "table" {
 			p.format = "json"
 		}
-		if p.format != "json" && p.format != "csv" {
-			return fmt.Errorf("--format for %s must be json or csv, got %q", p.action, p.format)
+		if p.format != "json" && p.format != "csv" && p.format != "encrypted" {
+			return fmt.Errorf("--format for %s must be json, csv, or encrypted, got %q", p.action, p.format)
 		}
 		if p.action == "import" && p.onConflict != "" && p.onConflict != "skip" && p.onConflict != "overwrite" {
 			return fmt.Errorf("--on-conflict must be skip or overwrite, got %q", p.onConflict)
@@ -618,14 +619,41 @@ func (p *Provider) generateTOTP(mgr *password.Manager) (provider.Credentials, er
 	}, nil
 }
 
-func (p *Provider) exportEntries(mgr *password.Manager) (provider.Credentials, error) {
-	format := password.FormatJSON
-	if p.format == "csv" {
-		format = password.FormatCSV
+// readExportPassword prompts for a password used to encrypt/decrypt an
+// export envelope. When confirm is true, requires the password be entered
+// twice and match.
+func (p *Provider) readExportPassword(label string, confirm bool) ([]byte, error) {
+	fmt.Fprintf(os.Stderr, "%s: ", label)
+	pw, err := readPassword()
+	fmt.Fprintln(os.Stderr)
+	if err != nil {
+		return nil, fmt.Errorf("read password: %w", err)
+	}
+	if len(pw) == 0 {
+		return nil, fmt.Errorf("password cannot be empty")
 	}
 
+	if confirm {
+		fmt.Fprintf(os.Stderr, "Confirm %s: ", label)
+		pw2, err := readPassword()
+		fmt.Fprintln(os.Stderr)
+		if err != nil {
+			secure.SecureZeroBytes(pw)
+			return nil, fmt.Errorf("read confirmation: %w", err)
+		}
+		if !bytes.Equal(pw, pw2) {
+			secure.SecureZeroBytes(pw)
+			secure.SecureZeroBytes(pw2)
+			return nil, fmt.Errorf("passwords do not match")
+		}
+		secure.SecureZeroBytes(pw2)
+	}
+
+	return pw, nil
+}
+
+func (p *Provider) exportEntries(mgr *password.Manager) (provider.Credentials, error) {
 	opts := password.ExportOptions{
-		Format:    format,
 		EntryType: password.EntryType(p.entryType),
 	}
 
@@ -649,7 +677,23 @@ func (p *Provider) exportEntries(mgr *password.Manager) (provider.Credentials, e
 		dest = p.file
 	}
 
-	count, err := mgr.Export(w, opts)
+	var count int
+	var err error
+
+	if p.format == "encrypted" {
+		pw, perr := p.readExportPassword("Encryption password", true)
+		if perr != nil {
+			return provider.Credentials{}, perr
+		}
+		defer secure.SecureZeroBytes(pw)
+		count, err = mgr.ExportEncrypted(w, opts, pw)
+	} else {
+		opts.Format = password.FormatJSON
+		if p.format == "csv" {
+			opts.Format = password.FormatCSV
+		}
+		count, err = mgr.Export(w, opts)
+	}
 	if err != nil {
 		return provider.Credentials{}, err
 	}
@@ -661,13 +705,7 @@ func (p *Provider) exportEntries(mgr *password.Manager) (provider.Credentials, e
 }
 
 func (p *Provider) importEntries(mgr *password.Manager) (provider.Credentials, error) {
-	format := password.FormatJSON
-	if p.format == "csv" {
-		format = password.FormatCSV
-	}
-
 	opts := password.ImportOptions{
-		Format:     format,
 		OnConflict: password.ConflictStrategy(p.onConflict),
 	}
 
@@ -687,7 +725,23 @@ func (p *Provider) importEntries(mgr *password.Manager) (provider.Credentials, e
 		r = p.stdin
 	}
 
-	result, err := mgr.Import(r, opts)
+	var result password.ImportResult
+	var err error
+
+	if p.format == "encrypted" {
+		pw, perr := p.readExportPassword("Decryption password", false)
+		if perr != nil {
+			return provider.Credentials{}, perr
+		}
+		defer secure.SecureZeroBytes(pw)
+		result, err = mgr.ImportEncrypted(r, opts, pw)
+	} else {
+		opts.Format = password.FormatJSON
+		if p.format == "csv" {
+			opts.Format = password.FormatCSV
+		}
+		result, err = mgr.Import(r, opts)
+	}
 	if err != nil {
 		return provider.Credentials{}, err
 	}

--- a/internal/provider/password/provider_test.go
+++ b/internal/provider/password/provider_test.go
@@ -799,11 +799,14 @@ func TestExport_EncryptedWritesEnvelope(t *testing.T) {
 		t.Fatalf("GetCredentials: %v", err)
 	}
 	out := stdout.Bytes()
-	if !json.Valid(out) {
-		t.Fatalf("envelope is not valid JSON: %q", string(out))
+	var envelope struct {
+		Algorithm string `json:"algorithm"`
 	}
-	if !strings.Contains(string(out), `"algorithm": "argon2id"`) {
-		t.Errorf("envelope missing algorithm field: %s", string(out))
+	if err := json.Unmarshal(out, &envelope); err != nil {
+		t.Fatalf("envelope is not valid JSON: %v\n%s", err, string(out))
+	}
+	if envelope.Algorithm != "argon2id" {
+		t.Errorf("envelope algorithm = %q, want argon2id\nfull envelope: %s", envelope.Algorithm, string(out))
 	}
 	if bytes.Contains(out, []byte("plaintext-secret")) {
 		t.Fatal("envelope leaked plaintext secret")

--- a/internal/provider/password/provider_test.go
+++ b/internal/provider/password/provider_test.go
@@ -266,15 +266,11 @@ func TestDeleteEntry_InvalidID(t *testing.T) {
 	}
 }
 
-// stubReadPassword overrides the package-level readPassword seam and
-// returns a restore func callers should defer.
-func stubReadPassword(t *testing.T, value string, err error) {
+// stubReadPassword overrides the package-level readPassword seam.
+func stubReadPassword(t *testing.T, value string) {
 	t.Helper()
 	orig := readPassword
 	readPassword = func() ([]byte, error) {
-		if err != nil {
-			return nil, err
-		}
 		return []byte(value), nil
 	}
 	t.Cleanup(func() { readPassword = orig })
@@ -312,7 +308,7 @@ func newTestProvider(kc keychain.Provider) (*Provider, *bytes.Buffer) {
 }
 
 func TestStorePassword_HappyPath(t *testing.T) {
-	stubReadPassword(t, "s3cret", nil)
+	stubReadPassword(t, "s3cret")
 
 	var storedKey, storedAccount string
 	var storedSecret []byte
@@ -687,7 +683,7 @@ func TestStoreTOTP_QRPath(t *testing.T) {
 }
 
 func TestStoreTOTP_ManualPath(t *testing.T) {
-	stubReadPassword(t, "JBSWY3DPEHPK3PXP", nil)
+	stubReadPassword(t, "JBSWY3DPEHPK3PXP")
 
 	mock := &mocks.MockProvider{
 		SetSecretFunc:       func(_, _ string, _ []byte) error { return nil },
@@ -777,6 +773,182 @@ func TestExport_WritesJSONToProviderStdout(t *testing.T) {
 	}
 	if !strings.Contains(creds.DisplayInfo, "Exported") {
 		t.Errorf("DisplayInfo = %q, want to mention Exported", creds.DisplayInfo)
+	}
+}
+
+func TestExport_EncryptedWritesEnvelope(t *testing.T) {
+	stubReadPassword(t, "export-password-1234")
+
+	mock := &mocks.MockProvider{
+		ListEntriesFunc: func(_ string) ([]keychain.KeychainEntry, error) {
+			return []keychain.KeychainEntry{
+				{Service: "sesh-password/password/github", Account: "testuser"},
+			}, nil
+		},
+		GetSecretFunc: func(_, _ string) ([]byte, error) {
+			return []byte("plaintext-secret"), nil
+		},
+	}
+
+	p, stdout := newTestProvider(mock)
+	p.action = "export"
+	p.format = "encrypted"
+
+	creds, err := p.GetCredentials()
+	if err != nil {
+		t.Fatalf("GetCredentials: %v", err)
+	}
+	out := stdout.Bytes()
+	if !json.Valid(out) {
+		t.Fatalf("envelope is not valid JSON: %q", string(out))
+	}
+	if !strings.Contains(string(out), `"algorithm": "argon2id"`) {
+		t.Errorf("envelope missing algorithm field: %s", string(out))
+	}
+	if bytes.Contains(out, []byte("plaintext-secret")) {
+		t.Fatal("envelope leaked plaintext secret")
+	}
+	if !strings.Contains(creds.DisplayInfo, "Exported 1") {
+		t.Errorf("DisplayInfo = %q", creds.DisplayInfo)
+	}
+}
+
+func TestExport_EncryptedPasswordMismatch(t *testing.T) {
+	calls := 0
+	orig := readPassword
+	readPassword = func() ([]byte, error) {
+		calls++
+		if calls == 1 {
+			return []byte("first-password"), nil
+		}
+		return []byte("second-password"), nil
+	}
+	t.Cleanup(func() { readPassword = orig })
+
+	mock := &mocks.MockProvider{
+		ListEntriesFunc: func(_ string) ([]keychain.KeychainEntry, error) { return nil, nil },
+	}
+	p, _ := newTestProvider(mock)
+	p.action = "export"
+	p.format = "encrypted"
+
+	_, err := p.GetCredentials()
+	if err == nil || !strings.Contains(err.Error(), "do not match") {
+		t.Fatalf("expected mismatch error, got %v", err)
+	}
+}
+
+func TestExport_EncryptedEmptyPassword(t *testing.T) {
+	stubReadPassword(t, "")
+
+	mock := &mocks.MockProvider{
+		ListEntriesFunc: func(_ string) ([]keychain.KeychainEntry, error) { return nil, nil },
+	}
+	p, _ := newTestProvider(mock)
+	p.action = "export"
+	p.format = "encrypted"
+
+	_, err := p.GetCredentials()
+	if err == nil || !strings.Contains(err.Error(), "empty") {
+		t.Fatalf("expected empty-password error, got %v", err)
+	}
+}
+
+func TestImport_EncryptedRoundTripThroughProvider(t *testing.T) {
+	stubReadPassword(t, "round-trip-password")
+
+	srcMock := &mocks.MockProvider{
+		ListEntriesFunc: func(_ string) ([]keychain.KeychainEntry, error) {
+			return []keychain.KeychainEntry{
+				// Account must match the manager's user (set by newTestProvider
+				// to "testuser") or parseEntry silently drops the row. The
+				// username "alice" lives in the service-key path segment.
+				{Service: "sesh-password/password/github/alice", Account: "testuser"},
+			}, nil
+		},
+		GetSecretFunc: func(_, _ string) ([]byte, error) {
+			return []byte("hunter2"), nil
+		},
+	}
+
+	pSrc, srcOut := newTestProvider(srcMock)
+	pSrc.action = "export"
+	pSrc.format = "encrypted"
+	if _, err := pSrc.GetCredentials(); err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	envelope := srcOut.Bytes()
+
+	stored := map[string][]byte{}
+	destMock := &mocks.MockProvider{
+		GetSecretFunc: func(_, service string) ([]byte, error) {
+			if v, ok := stored[service]; ok {
+				return v, nil
+			}
+			return nil, keychain.ErrNotFound
+		},
+		SetSecretFunc: func(_, service string, secret []byte) error {
+			stored[service] = append([]byte(nil), secret...)
+			return nil
+		},
+		SetDescriptionFunc: func(_, _, _ string) error { return nil },
+		ListEntriesFunc:    func(_ string) ([]keychain.KeychainEntry, error) { return nil, nil },
+	}
+	pDest, _ := newTestProvider(destMock)
+	pDest.action = "import"
+	pDest.format = "encrypted"
+	pDest.stdin = bytes.NewReader(envelope)
+
+	creds, err := pDest.GetCredentials()
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if !strings.Contains(creds.DisplayInfo, "Imported 1") {
+		t.Errorf("DisplayInfo = %q", creds.DisplayInfo)
+	}
+	if got := stored["sesh-password/password/github/alice"]; string(got) != "hunter2" {
+		t.Errorf("stored secret = %q, want hunter2 (full map: %v)", got, stored)
+	}
+}
+
+func TestImport_EncryptedWrongPassword(t *testing.T) {
+	calls := 0
+	orig := readPassword
+	readPassword = func() ([]byte, error) {
+		calls++
+		switch calls {
+		case 1, 2:
+			return []byte("password-a"), nil
+		default:
+			return []byte("password-b"), nil
+		}
+	}
+	t.Cleanup(func() { readPassword = orig })
+
+	srcMock := &mocks.MockProvider{
+		ListEntriesFunc: func(_ string) ([]keychain.KeychainEntry, error) {
+			return []keychain.KeychainEntry{
+				{Service: "sesh-password/password/github", Account: "alice"},
+			}, nil
+		},
+		GetSecretFunc: func(_, _ string) ([]byte, error) { return []byte("s"), nil },
+	}
+	pSrc, srcOut := newTestProvider(srcMock)
+	pSrc.action = "export"
+	pSrc.format = "encrypted"
+	if _, err := pSrc.GetCredentials(); err != nil {
+		t.Fatalf("export: %v", err)
+	}
+
+	destMock := &mocks.MockProvider{}
+	pDest, _ := newTestProvider(destMock)
+	pDest.action = "import"
+	pDest.format = "encrypted"
+	pDest.stdin = bytes.NewReader(srcOut.Bytes())
+
+	_, err := pDest.GetCredentials()
+	if err == nil {
+		t.Fatal("expected error for wrong password")
 	}
 }
 

--- a/sesh/cmd/sesh/app.go
+++ b/sesh/cmd/sesh/app.go
@@ -43,6 +43,7 @@ type App struct {
 	Exit          ExitFunc
 	ClipboardCopy ClipboardCopyFunc
 	TimeNow       TimeNowFunc
+	Stdin         io.Reader
 	Stdout        io.Writer
 	Stderr        io.Writer
 	VersionInfo   VersionInfo
@@ -80,6 +81,7 @@ func NewDefaultApp(versionInfo VersionInfo, kc keychain.Provider) *App {
 			return clipboard.CopyWithAutoClear(text, 30*time.Second)
 		},
 		TimeNow:     time.Now,
+		Stdin:       os.Stdin,
 		Stdout:      os.Stdout,
 		Stderr:      os.Stderr,
 		VersionInfo: versionInfo,

--- a/sesh/cmd/sesh/main.go
+++ b/sesh/cmd/sesh/main.go
@@ -188,9 +188,9 @@ func promptMasterPassword(prompt string) ([]byte, error) {
 		return nil, err
 	}
 	pw, err := term.ReadPassword(int(os.Stdin.Fd()))
-	if _, perr := fmt.Fprintln(os.Stderr); perr != nil {
-		return nil, perr
-	}
+	// Best-effort newline after the hidden input. Don't let a stderr write
+	// error mask a real read error.
+	fmt.Fprintln(os.Stderr) //nolint:errcheck // see comment above
 	if err != nil {
 		return nil, fmt.Errorf("read password: %w", err)
 	}

--- a/sesh/cmd/sesh/main.go
+++ b/sesh/cmd/sesh/main.go
@@ -80,7 +80,8 @@ func needsCredentialStore(args []string) bool {
 		case "--help", "-help", "-h",
 			"--version", "-version",
 			"--list-services", "-list-services",
-			"--migrate", "-migrate":
+			"--migrate", "-migrate",
+			"--rekey", "-rekey":
 			return false
 		}
 	}
@@ -360,6 +361,18 @@ func runMigrate(app *App) error {
 	return nil
 }
 
+// remainingArgs returns args following (but not including) the first
+// occurrence of name. Used to forward sub-flags to handlers like runRekey
+// without depending on a specific flag-package layout.
+func remainingArgs(args []string, name string) []string {
+	for i, a := range args {
+		if a == name {
+			return args[i+1:]
+		}
+	}
+	return nil
+}
+
 // fatal prints an error to stderr and exits
 func fatal(app *App, err error) {
 	if _, printErr := fmt.Fprintf(app.Stderr, "❌ %v\n", err); printErr != nil {
@@ -386,6 +399,12 @@ func run(app *App, args []string) {
 			return
 		case "--migrate", "-migrate":
 			if err := runMigrate(app); err != nil {
+				fatal(app, err)
+			}
+			return
+		case "--rekey", "-rekey":
+			rest := remainingArgs(args, arg)
+			if err := runRekey(app, rest, keychain.NewDefaultProvider()); err != nil {
 				fatal(app, err)
 			}
 			return

--- a/sesh/cmd/sesh/main.go
+++ b/sesh/cmd/sesh/main.go
@@ -318,7 +318,7 @@ func runMigrate(app *App) error {
 	// Use bufio so a bare Enter (the canonical "No" for [y/N]) is read
 	// as an empty line rather than surfacing "unexpected newline" from
 	// fmt.Scanln and aborting.
-	line, err := bufio.NewReader(os.Stdin).ReadString('\n')
+	line, err := bufio.NewReader(app.Stdin).ReadString('\n')
 	if err != nil && !errors.Is(err, io.EOF) {
 		return fmt.Errorf("failed to read input: %w", err)
 	}

--- a/sesh/cmd/sesh/main.go
+++ b/sesh/cmd/sesh/main.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"syscall"
 
+	"golang.org/x/term"
+
 	"github.com/bashhack/sesh/internal/database"
 	"github.com/bashhack/sesh/internal/keychain"
 	"github.com/bashhack/sesh/internal/migration"
@@ -127,18 +129,13 @@ func buildProvider() (keychain.Provider, io.Closer, error) {
 // first run) and returns an opened, schema-initialized SQLite store. The
 // caller must Close it.
 func openSQLiteStore() (*database.Store, error) {
-	u, err := user.Current()
-	if err != nil {
-		return nil, fmt.Errorf("determine current user: %w", err)
-	}
-
 	dbPath, err := database.DefaultDBPath()
 	if err != nil {
 		return nil, fmt.Errorf("resolve database path: %w", err)
 	}
 
-	ks := database.NewKeychainSource(keychain.NewDefaultProvider(), u.Username)
-	if err := ensureMasterKey(ks, filepath.Dir(dbPath)); err != nil {
+	ks, err := buildKeySource(filepath.Dir(dbPath))
+	if err != nil {
 		return nil, err
 	}
 
@@ -155,6 +152,49 @@ func openSQLiteStore() (*database.Store, error) {
 	}
 
 	return store, nil
+}
+
+// buildKeySource selects the KeySource based on SESH_KEY_SOURCE.
+// Defaults to the macOS Keychain. "password" selects MasterPasswordSource,
+// which stores its KDF salt in a sidecar file alongside the DB.
+func buildKeySource(dataDir string) (database.KeySource, error) {
+	switch os.Getenv("SESH_KEY_SOURCE") {
+	case "password":
+		mps := database.NewMasterPasswordSource(dataDir, promptMasterPassword)
+		return mps, nil
+	case "", "keychain":
+		u, err := user.Current()
+		if err != nil {
+			return nil, fmt.Errorf("determine current user: %w", err)
+		}
+		ks := database.NewKeychainSource(keychain.NewDefaultProvider(), u.Username)
+		if err := ensureMasterKey(ks, dataDir); err != nil {
+			return nil, err
+		}
+		return ks, nil
+	default:
+		return nil, fmt.Errorf("unknown SESH_KEY_SOURCE %q (valid: keychain, password)", os.Getenv("SESH_KEY_SOURCE"))
+	}
+}
+
+// promptMasterPassword reads a password from the terminal without echo.
+// Checks SESH_MASTER_PASSWORD env var first to support non-interactive use.
+func promptMasterPassword(prompt string) ([]byte, error) {
+	if envPw := os.Getenv("SESH_MASTER_PASSWORD"); envPw != "" {
+		return []byte(envPw), nil
+	}
+
+	if _, err := fmt.Fprint(os.Stderr, prompt); err != nil {
+		return nil, err
+	}
+	pw, err := term.ReadPassword(int(os.Stdin.Fd()))
+	if _, perr := fmt.Fprintln(os.Stderr); perr != nil {
+		return nil, perr
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read password: %w", err)
+	}
+	return pw, nil
 }
 
 // ensureMasterKey verifies a master encryption key exists in the keychain,

--- a/sesh/cmd/sesh/main.go
+++ b/sesh/cmd/sesh/main.go
@@ -161,6 +161,16 @@ func buildKeySource(dataDir string) (database.KeySource, error) {
 	switch os.Getenv("SESH_KEY_SOURCE") {
 	case "password":
 		mps := database.NewMasterPasswordSource(dataDir, promptMasterPassword)
+		// Eagerly unlock so every operation — including metadata-only reads
+		// like --list and --delete — requires the master password. Without
+		// this, the store would only prompt on decryption, letting an
+		// attacker with filesystem access list and delete entries without
+		// the password.
+		key, err := mps.GetEncryptionKey()
+		if err != nil {
+			return nil, err
+		}
+		secure.SecureZeroBytes(key)
 		return mps, nil
 	case "", "keychain":
 		u, err := user.Current()

--- a/sesh/cmd/sesh/main_test.go
+++ b/sesh/cmd/sesh/main_test.go
@@ -56,6 +56,7 @@ func newTestHarness() *testHarness {
 			Exit:          func(int) {},
 			ClipboardCopy: func(string) error { return nil },
 			TimeNow:       time.Now,
+			Stdin:         bytes.NewReader(nil),
 			Stdout:        stdoutBuf,
 			Stderr:        stderrBuf,
 			VersionInfo:   VersionInfo{Version: "test-version", Commit: "test-commit", Date: "test-date"},

--- a/sesh/cmd/sesh/rekey.go
+++ b/sesh/cmd/sesh/rekey.go
@@ -67,6 +67,12 @@ func runRekey(app *App, args []string, kc keychain.Provider) (err error) {
 		}
 		return fmt.Errorf("stat database: %w", err)
 	}
+	preBackupPath := dbPath + rekeyBackupSuffix
+	if _, err := os.Stat(preBackupPath); err == nil {
+		return fmt.Errorf("backup path %s already exists; remove it (or rename to preserve a prior backup) and retry", preBackupPath)
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat backup path: %w", err)
+	}
 	if err := checkTargetKeyStateClean(*target, dataDir, kc); err != nil {
 		return err
 	}
@@ -196,7 +202,7 @@ func runRekey(app *App, args []string, kc keychain.Provider) (err error) {
 	}
 	srcStoreOpen = false
 
-	backupPath = dbPath + rekeyBackupSuffix
+	backupPath = preBackupPath
 	// Brief window between these two renames where dbPath does not exist;
 	// a concurrent open during this interval will fail with ENOENT. POSIX
 	// has no portable atomic-two-file-swap, so we accept the window for

--- a/sesh/cmd/sesh/rekey.go
+++ b/sesh/cmd/sesh/rekey.go
@@ -144,7 +144,7 @@ func runRekey(app *App, args []string, kc keychain.Provider) (err error) {
 	if _, perr := fmt.Fprintf(app.Stderr, "  rollback file after: %s%s\n", dbPath, rekeyBackupSuffix); perr != nil {
 		return perr
 	}
-	confirmed, err := promptYesNo(app.Stderr, "\nProceed? [y/N]: ")
+	confirmed, err := promptYesNo(app.Stdin, app.Stderr, "\nProceed? [y/N]: ")
 	if err != nil {
 		return err
 	}
@@ -197,6 +197,10 @@ func runRekey(app *App, args []string, kc keychain.Provider) (err error) {
 	srcStoreOpen = false
 
 	backupPath = dbPath + rekeyBackupSuffix
+	// Brief window between these two renames where dbPath does not exist;
+	// a concurrent open during this interval will fail with ENOENT. POSIX
+	// has no portable atomic-two-file-swap, so we accept the window for
+	// this single-user CLI.
 	if err := os.Rename(dbPath, backupPath); err != nil {
 		return fmt.Errorf("rename source DB to backup: %w", err)
 	}
@@ -363,11 +367,11 @@ func unusedKeyStateNote(oldSource, dataDir string) string {
 
 // promptYesNo reads a y/N answer from stdin. Empty input (bare Enter) is "No"
 // to match runMigrate's behaviour. Returns true only on explicit "y" or "Y".
-func promptYesNo(stderr io.Writer, prompt string) (bool, error) {
+func promptYesNo(stdin io.Reader, stderr io.Writer, prompt string) (bool, error) {
 	if _, err := fmt.Fprint(stderr, prompt); err != nil {
 		return false, err
 	}
-	line, err := bufio.NewReader(os.Stdin).ReadString('\n')
+	line, err := bufio.NewReader(stdin).ReadString('\n')
 	if err != nil && !errors.Is(err, io.EOF) {
 		return false, fmt.Errorf("read confirmation: %w", err)
 	}

--- a/sesh/cmd/sesh/rekey.go
+++ b/sesh/cmd/sesh/rekey.go
@@ -1,0 +1,376 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+
+	"github.com/bashhack/sesh/internal/database"
+	"github.com/bashhack/sesh/internal/keychain"
+	"github.com/bashhack/sesh/internal/migration"
+	"github.com/bashhack/sesh/internal/secure"
+)
+
+const (
+	rekeyDestSuffix   = ".new"
+	rekeyBackupSuffix = ".pre-rekey"
+	encKeyService     = "sesh-sqlite-encryption-key"
+	sidecarFile       = "passwords.key"
+)
+
+// runRekey re-encrypts the SQLite store under a different KeySource and
+// atomically swaps the result into place. The original DB is preserved at
+// <dbPath>.pre-rekey for rollback. The old key state (sidecar or keychain
+// entry) is left untouched; it becomes unused but is reported in the final
+// summary so the user can clean it up via OS tools if desired.
+//
+// kc is the keychain provider used for keychain-mode key state checks and
+// cleanup. Production passes keychain.NewDefaultProvider(); tests inject
+// a mock. It can be nil if --to=password and the current source isn't
+// keychain — keychain branches are only entered when the source or target
+// is "keychain".
+func runRekey(app *App, args []string, kc keychain.Provider) (err error) {
+	if os.Getenv("SESH_BACKEND") != "sqlite" {
+		return fmt.Errorf("rekey requires SESH_BACKEND=sqlite")
+	}
+
+	fs := flag.NewFlagSet("rekey", flag.ContinueOnError)
+	fs.SetOutput(app.Stderr)
+	target := fs.String("to", "", "Target key source: keychain or password")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *target != "keychain" && *target != "password" {
+		return fmt.Errorf("--to must be 'keychain' or 'password', got %q", *target)
+	}
+
+	current := currentKeySourceName()
+	if current == *target {
+		return fmt.Errorf("already using %s; nothing to do", *target)
+	}
+
+	dbPath, err := database.DefaultDBPath()
+	if err != nil {
+		return fmt.Errorf("resolve database path: %w", err)
+	}
+	dataDir := filepath.Dir(dbPath)
+
+	if _, err := os.Stat(dbPath); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("no database to rekey at %s", dbPath)
+		}
+		return fmt.Errorf("stat database: %w", err)
+	}
+	if err := checkTargetKeyStateClean(*target, dataDir, kc); err != nil {
+		return err
+	}
+
+	srcKS, err := newKeySourceByName(current, dataDir, kc)
+	if err != nil {
+		return fmt.Errorf("build source key source: %w", err)
+	}
+	srcStore, err := database.Open(dbPath, srcKS)
+	if err != nil {
+		return fmt.Errorf("open source database: %w", err)
+	}
+
+	// Rollback state — tracked through the function and consulted by a
+	// deferred cleanup. Anything that's *true / non-empty when err != nil
+	// gets unwound. On success commit, we zero them so cleanup is a no-op.
+	var (
+		destStore       *database.Store
+		destPath        string
+		targetCreated   bool
+		srcStoreOpen    = true
+		backupPath      string
+		originalRenamed bool
+	)
+
+	defer func() {
+		if srcStoreOpen {
+			if cerr := srcStore.Close(); cerr != nil {
+				err = appendErr(err, "close source store", cerr)
+			}
+		}
+		if err == nil {
+			return
+		}
+		if destStore != nil {
+			if cerr := destStore.Close(); cerr != nil {
+				err = appendErr(err, "rollback close destination store", cerr)
+			}
+		}
+		if destPath != "" {
+			if rerr := os.Remove(destPath); rerr != nil && !os.IsNotExist(rerr) {
+				err = appendErr(err, "rollback remove destination DB", rerr)
+			}
+		}
+		if targetCreated {
+			if cerr := cleanupNewKeyState(*target, dataDir, kc); cerr != nil {
+				err = appendErr(err, "rollback target key state", cerr)
+			}
+		}
+		if originalRenamed {
+			if rerr := os.Rename(backupPath, dbPath); rerr != nil {
+				err = appendErr(err, fmt.Sprintf("restore original DB to %s", dbPath), rerr)
+			}
+		}
+	}()
+
+	// Surface a wrong-source-password error before doing anything destructive.
+	srcKey, err := srcKS.GetEncryptionKey()
+	if err != nil {
+		return fmt.Errorf("unlock source: %w", err)
+	}
+	secure.SecureZeroBytes(srcKey)
+
+	plan, err := migration.Plan(srcStore)
+	if err != nil {
+		return fmt.Errorf("scan source: %w", err)
+	}
+
+	if _, perr := fmt.Fprintf(app.Stderr, "About to re-encrypt %d entries: %s → %s\n", len(plan), current, *target); perr != nil {
+		return perr
+	}
+	if _, perr := fmt.Fprintf(app.Stderr, "  source DB:           %s\n", dbPath); perr != nil {
+		return perr
+	}
+	if _, perr := fmt.Fprintf(app.Stderr, "  rollback file after: %s%s\n", dbPath, rekeyBackupSuffix); perr != nil {
+		return perr
+	}
+	confirmed, err := promptYesNo(app.Stderr, "\nProceed? [y/N]: ")
+	if err != nil {
+		return err
+	}
+	if !confirmed {
+		if _, perr := fmt.Fprintln(app.Stderr, "Rekey cancelled."); perr != nil {
+			return perr
+		}
+		return nil
+	}
+
+	destKS, err := newKeySourceByName(*target, dataDir, kc)
+	if err != nil {
+		return fmt.Errorf("build target key source: %w", err)
+	}
+	if err := initializeTargetKeySource(destKS, *target); err != nil {
+		return fmt.Errorf("set up target key source: %w", err)
+	}
+	targetCreated = true
+
+	destPath = dbPath + rekeyDestSuffix
+	if _, err := os.Stat(destPath); err == nil {
+		return fmt.Errorf("destination path %s already exists; remove it and retry", destPath)
+	}
+
+	destStore, err = database.Open(destPath, destKS)
+	if err != nil {
+		return fmt.Errorf("open destination database: %w", err)
+	}
+	if err := destStore.InitKeyMetadata(); err != nil {
+		return fmt.Errorf("init target key metadata: %w", err)
+	}
+
+	result, err := migration.Migrate(srcStore, destStore)
+	if err != nil {
+		return fmt.Errorf("copy entries: %w", err)
+	}
+	if len(result.Errors) > 0 {
+		return fmt.Errorf("copy reported %d errors:\n  %s", len(result.Errors), strings.Join(result.Errors, "\n  "))
+	}
+
+	// Close stores BEFORE rename so SQLite checkpoints WAL and removes the
+	// -wal/-shm sidecars; otherwise the rename leaves orphans.
+	if err := destStore.Close(); err != nil {
+		return fmt.Errorf("close destination store: %w", err)
+	}
+	destStore = nil // already closed; don't re-close in rollback
+	if err := srcStore.Close(); err != nil {
+		return fmt.Errorf("close source store: %w", err)
+	}
+	srcStoreOpen = false
+
+	backupPath = dbPath + rekeyBackupSuffix
+	if err := os.Rename(dbPath, backupPath); err != nil {
+		return fmt.Errorf("rename source DB to backup: %w", err)
+	}
+	originalRenamed = true
+	if err := os.Rename(destPath, dbPath); err != nil {
+		return fmt.Errorf("rename destination into place: %w", err)
+	}
+
+	// Commit: clear rollback state so the deferred cleanup is a no-op.
+	destPath = ""
+	targetCreated = false
+	originalRenamed = false
+
+	if _, perr := fmt.Fprintf(app.Stderr, "\nRekeyed %d entries: %s → %s\n", result.Migrated, current, *target); perr != nil {
+		return perr
+	}
+	if _, perr := fmt.Fprintf(app.Stderr, "Original DB preserved at %s\n", backupPath); perr != nil {
+		return perr
+	}
+	if msg := unusedKeyStateNote(current, dataDir); msg != "" {
+		if _, perr := fmt.Fprintln(app.Stderr, msg); perr != nil {
+			return perr
+		}
+	}
+	return nil
+}
+
+// appendErr decorates a primary error with a secondary one from a cleanup or
+// rollback path. Keeps the wrapped chain anchored on the first failure.
+func appendErr(primary error, label string, secondary error) error {
+	if primary == nil {
+		return fmt.Errorf("%s: %w", label, secondary)
+	}
+	return fmt.Errorf("%w (%s also failed: %v)", primary, label, secondary)
+}
+
+// currentKeySourceName returns the active key source as named by SESH_KEY_SOURCE.
+// Empty defaults to "keychain" to match buildKeySource's behaviour.
+func currentKeySourceName() string {
+	v := os.Getenv("SESH_KEY_SOURCE")
+	if v == "" {
+		return "keychain"
+	}
+	return v
+}
+
+// newKeySourceByName constructs a KeySource without unlocking or initialising
+// it — the caller decides when to call GetEncryptionKey (which is what
+// triggers the master password prompt or keychain key generation).
+func newKeySourceByName(name, dataDir string, kc keychain.Provider) (database.KeySource, error) {
+	switch name {
+	case "password":
+		return database.NewMasterPasswordSource(dataDir, promptMasterPassword), nil
+	case "keychain":
+		u, err := user.Current()
+		if err != nil {
+			return nil, fmt.Errorf("determine current user: %w", err)
+		}
+		return database.NewKeychainSource(kc, u.Username), nil
+	default:
+		return nil, fmt.Errorf("unknown key source %q (valid: keychain, password)", name)
+	}
+}
+
+// initializeTargetKeySource persists fresh key state for ks. For password
+// mode this means writing a new sidecar (via GetEncryptionKey, which also
+// derives the key). For keychain mode it means generating a random 32-byte
+// key and storing it under the canonical service name.
+func initializeTargetKeySource(ks database.KeySource, target string) error {
+	switch target {
+	case "password":
+		k, err := ks.GetEncryptionKey()
+		if err != nil {
+			return err
+		}
+		secure.SecureZeroBytes(k)
+		return nil
+	case "keychain":
+		k, err := database.GenerateEncryptionKey()
+		if err != nil {
+			return err
+		}
+		defer secure.SecureZeroBytes(k)
+		return ks.StoreEncryptionKey(k)
+	default:
+		return fmt.Errorf("unknown target %q", target)
+	}
+}
+
+// checkTargetKeyStateClean refuses if the target's persistent state is
+// already initialised. Refusing is safer than silently overwriting — the
+// target sidecar's salt or the target keychain entry's stored key may be
+// in use by something the user still needs.
+func checkTargetKeyStateClean(target, dataDir string, kc keychain.Provider) error {
+	switch target {
+	case "password":
+		path := filepath.Join(dataDir, sidecarFile)
+		if _, err := os.Stat(path); err == nil {
+			return fmt.Errorf("target sidecar %s already exists; remove it manually before rekey", path)
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("stat target sidecar: %w", err)
+		}
+		return nil
+	case "keychain":
+		u, err := user.Current()
+		if err != nil {
+			return fmt.Errorf("determine current user: %w", err)
+		}
+		existing, err := kc.GetSecret(u.Username, encKeyService)
+		if err == nil {
+			secure.SecureZeroBytes(existing)
+			return fmt.Errorf("target keychain entry already exists for account %q; remove it via Keychain Access (or `security delete-generic-password -a %s -s %s`) before rekey", u.Username, u.Username, encKeyService)
+		}
+		if !errors.Is(err, keychain.ErrNotFound) {
+			return fmt.Errorf("check target keychain entry: %w", err)
+		}
+		return nil
+	default:
+		return fmt.Errorf("unknown target %q", target)
+	}
+}
+
+// cleanupNewKeyState removes the key state that initializeTargetKeySource
+// created during rekey. Called only on failure paths after the target source
+// successfully initialised.
+func cleanupNewKeyState(target, dataDir string, kc keychain.Provider) error {
+	switch target {
+	case "password":
+		path := filepath.Join(dataDir, sidecarFile)
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove target sidecar: %w", err)
+		}
+		return nil
+	case "keychain":
+		u, err := user.Current()
+		if err != nil {
+			return fmt.Errorf("determine current user: %w", err)
+		}
+		if err := kc.DeleteEntry(u.Username, encKeyService); err != nil && !errors.Is(err, keychain.ErrNotFound) {
+			return fmt.Errorf("delete target keychain entry: %w", err)
+		}
+		return nil
+	default:
+		return fmt.Errorf("unknown target %q", target)
+	}
+}
+
+// unusedKeyStateNote returns a user-facing message about the now-unused old
+// key state, or empty if there's nothing to say.
+func unusedKeyStateNote(oldSource, dataDir string) string {
+	switch oldSource {
+	case "password":
+		path := filepath.Join(dataDir, sidecarFile)
+		if _, err := os.Stat(path); err == nil {
+			return fmt.Sprintf("Note: old master-password sidecar at %s is now unused. Remove it manually if you want to clean up.", path)
+		}
+		return ""
+	case "keychain":
+		return "Note: old keychain entry '" + encKeyService + "' is now unused. Remove it via Keychain Access if you want to clean up."
+	default:
+		return ""
+	}
+}
+
+// promptYesNo reads a y/N answer from stdin. Empty input (bare Enter) is "No"
+// to match runMigrate's behaviour. Returns true only on explicit "y" or "Y".
+func promptYesNo(stderr io.Writer, prompt string) (bool, error) {
+	if _, err := fmt.Fprint(stderr, prompt); err != nil {
+		return false, err
+	}
+	line, err := bufio.NewReader(os.Stdin).ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return false, fmt.Errorf("read confirmation: %w", err)
+	}
+	answer := strings.TrimSpace(line)
+	return answer == "y" || answer == "Y", nil
+}

--- a/sesh/cmd/sesh/rekey_test.go
+++ b/sesh/cmd/sesh/rekey_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -64,30 +65,46 @@ func rekeyTestApp(stdin string) (*App, *bytes.Buffer) {
 }
 
 type kcMock struct {
-	stored []byte
-	mu     sync.Mutex
+	store map[string][]byte
+	mu    sync.Mutex
 }
 
+// kcMockKey routes mock entries by both account and service so the mock
+// can't accidentally satisfy a lookup against the wrong (account, service)
+// pair.
+func kcMockKey(account, service string) string {
+	return account + "|" + service
+}
+
+// newKCMock builds a keychain mock. If stored is non-nil, it pre-populates
+// the encryption key under the canonical (current_user, encKeyService)
+// pair so KeychainSource lookups find it.
 func newKCMock(stored []byte) *kcMock {
-	if stored == nil {
-		return &kcMock{}
+	m := &kcMock{store: make(map[string][]byte)}
+	if stored != nil {
+		u, err := user.Current()
+		if err != nil {
+			panic(fmt.Errorf("user.Current: %w", err))
+		}
+		m.store[kcMockKey(u.Username, encKeyService)] = append([]byte{}, stored...)
 	}
-	return &kcMock{stored: append([]byte{}, stored...)}
+	return m
 }
 
-func (m *kcMock) GetSecret(_, _ string) ([]byte, error) {
+func (m *kcMock) GetSecret(account, service string) ([]byte, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if m.stored == nil {
+	v, ok := m.store[kcMockKey(account, service)]
+	if !ok {
 		return nil, keychain.ErrNotFound
 	}
-	return append([]byte{}, m.stored...), nil
+	return append([]byte{}, v...), nil
 }
 
-func (m *kcMock) SetSecret(_, _ string, secret []byte) error {
+func (m *kcMock) SetSecret(account, service string, secret []byte) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.stored = append([]byte{}, secret...)
+	m.store[kcMockKey(account, service)] = append([]byte{}, secret...)
 	return nil
 }
 
@@ -96,10 +113,10 @@ func (m *kcMock) SetSecretString(_, _, _ string) error                   { retur
 func (m *kcMock) GetMFASerialBytes(_, _ string) ([]byte, error)          { return nil, keychain.ErrNotFound }
 func (m *kcMock) ListEntries(_ string) ([]keychain.KeychainEntry, error) { return nil, nil }
 func (m *kcMock) SetDescription(_, _, _ string) error                    { return nil }
-func (m *kcMock) DeleteEntry(_, _ string) error {
+func (m *kcMock) DeleteEntry(account, service string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.stored = nil
+	delete(m.store, kcMockKey(account, service))
 	return nil
 }
 
@@ -291,6 +308,30 @@ func TestRekey_RefusesIfTargetSidecarExists(t *testing.T) {
 	}
 }
 
+func TestRekey_RefusesIfTargetKeychainEntryExists(t *testing.T) {
+	env := setupRekeyEnv(t)
+	t.Setenv("SESH_KEY_SOURCE", "password")
+	t.Setenv("SESH_MASTER_PASSWORD", "test-password-1234")
+	populatePasswordStore(t, env, map[string]string{
+		"sesh-password/password/github/alice": "hunter2",
+	})
+
+	kc := newKCMock(hexKey())
+
+	app, _ := rekeyTestApp("")
+	err := runRekey(app, []string{"--to=keychain"}, kc)
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("expected target-keychain-exists error, got %v", err)
+	}
+
+	if _, err := os.Stat(env.dbPath); err != nil {
+		t.Fatalf("source DB should still exist: %v", err)
+	}
+	if _, err := os.Stat(env.dbPath + rekeyBackupSuffix); err == nil {
+		t.Fatalf("backup file should not exist on refusal")
+	}
+}
+
 func TestRekey_KeychainToPassword(t *testing.T) {
 	env := setupRekeyEnv(t)
 	kc := newKCMock(hexKey())
@@ -346,7 +387,7 @@ func TestRekey_PasswordToKeychain(t *testing.T) {
 	}
 	populatePasswordStore(t, env, entries)
 
-	kc := &kcMock{}
+	kc := newKCMock(nil)
 
 	app, stderr := rekeyTestApp("y\n")
 	if err := runRekey(app, []string{"--to=keychain"}, kc); err != nil {
@@ -359,10 +400,11 @@ func TestRekey_PasswordToKeychain(t *testing.T) {
 	if _, err := os.Stat(env.sidecarPath); err != nil {
 		t.Errorf("old sidecar should still exist: %v", err)
 	}
-	if kc.stored == nil {
-		t.Errorf("new keychain entry not stored")
-	} else if len(kc.stored) != 64 {
-		t.Errorf("new keychain entry hex length = %d, want 64", len(kc.stored))
+	storedKey, err := kc.GetSecret(env.account, encKeyService)
+	if err != nil {
+		t.Errorf("new keychain entry not stored: %v", err)
+	} else if len(storedKey) != 64 {
+		t.Errorf("new keychain entry hex length = %d, want 64", len(storedKey))
 	}
 	if _, err := os.Stat(env.dbPath + rekeyBackupSuffix); err != nil {
 		t.Errorf("backup DB missing: %v", err)
@@ -478,6 +520,11 @@ func TestRekey_CancelledLeavesNoChanges(t *testing.T) {
 	if _, err := os.Stat(env.dbPath + rekeyDestSuffix); err == nil {
 		t.Errorf(".new DB should not exist after cancellation")
 	}
+
+	got := readEntriesViaKeychain(t, env, kc, []string{"sesh-password/password/github/alice"})
+	if got["sesh-password/password/github/alice"] != "hunter2" {
+		t.Errorf("original entry corrupted after cancellation, got %q want %q", got["sesh-password/password/github/alice"], "hunter2")
+	}
 }
 
 func TestRekey_RoundtripKeychainPasswordKeychain(t *testing.T) {
@@ -500,7 +547,7 @@ func TestRekey_RoundtripKeychainPasswordKeychain(t *testing.T) {
 		t.Fatalf("clean step-1 backup: %v", err)
 	}
 
-	kc2 := &kcMock{}
+	kc2 := newKCMock(nil)
 	app2, _ := rekeyTestApp("y\n")
 	if err := runRekey(app2, []string{"--to=keychain"}, kc2); err != nil {
 		t.Fatalf("second rekey: %v", err)
@@ -558,10 +605,14 @@ func TestCleanupNewKeyState_PasswordNoSidecarIsOK(t *testing.T) {
 
 func TestCleanupNewKeyState_KeychainDeletesEntry(t *testing.T) {
 	kc := newKCMock(hexKey())
+	u, err := user.Current()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if err := cleanupNewKeyState("keychain", "", kc); err != nil {
 		t.Fatalf("cleanup: %v", err)
 	}
-	if _, err := kc.GetSecret("anyone", encKeyService); !errors.Is(err, keychain.ErrNotFound) {
+	if _, err := kc.GetSecret(u.Username, encKeyService); !errors.Is(err, keychain.ErrNotFound) {
 		t.Errorf("keychain entry should be deleted, got %v", err)
 	}
 }

--- a/sesh/cmd/sesh/rekey_test.go
+++ b/sesh/cmd/sesh/rekey_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -489,5 +490,134 @@ func TestRekey_RoundtripKeychainPasswordKeychain(t *testing.T) {
 		if got[svc] != want {
 			t.Errorf("entry %s after roundtrip = %q, want %q", svc, got[svc], want)
 		}
+	}
+}
+
+func TestAppendErr_NilPrimary(t *testing.T) {
+	got := appendErr(nil, "label", errors.New("secondary"))
+	if got == nil || got.Error() != "label: secondary" {
+		t.Errorf("got %v, want 'label: secondary'", got)
+	}
+}
+
+func TestAppendErr_WithPrimary(t *testing.T) {
+	primary := errors.New("primary failure")
+	got := appendErr(primary, "rollback step", errors.New("cleanup failed"))
+	if !strings.Contains(got.Error(), "primary failure") {
+		t.Errorf("primary not preserved in %q", got.Error())
+	}
+	if !strings.Contains(got.Error(), "rollback step also failed: cleanup failed") {
+		t.Errorf("secondary not labelled correctly in %q", got.Error())
+	}
+	if !errors.Is(got, primary) {
+		t.Errorf("appended error should still wrap primary for errors.Is")
+	}
+}
+
+func TestCleanupNewKeyState_PasswordRemovesSidecar(t *testing.T) {
+	dir := t.TempDir()
+	sidecar := filepath.Join(dir, "passwords.key")
+	if err := os.WriteFile(sidecar, []byte("anything"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := cleanupNewKeyState("password", dir, nil); err != nil {
+		t.Fatalf("cleanup: %v", err)
+	}
+	if _, err := os.Stat(sidecar); !os.IsNotExist(err) {
+		t.Errorf("sidecar should be removed, stat err = %v", err)
+	}
+}
+
+func TestCleanupNewKeyState_PasswordNoSidecarIsOK(t *testing.T) {
+	if err := cleanupNewKeyState("password", t.TempDir(), nil); err != nil {
+		t.Errorf("cleanup of missing sidecar should succeed, got %v", err)
+	}
+}
+
+func TestCleanupNewKeyState_KeychainDeletesEntry(t *testing.T) {
+	kc := newKCMock(hexKey())
+	if err := cleanupNewKeyState("keychain", "", kc); err != nil {
+		t.Fatalf("cleanup: %v", err)
+	}
+	if _, err := kc.GetSecret("anyone", encKeyService); !errors.Is(err, keychain.ErrNotFound) {
+		t.Errorf("keychain entry should be deleted, got %v", err)
+	}
+}
+
+func TestCleanupNewKeyState_UnknownTarget(t *testing.T) {
+	if err := cleanupNewKeyState("banana", "", nil); err == nil {
+		t.Error("expected error for unknown target")
+	}
+}
+
+func TestCheckTargetKeyStateClean_UnknownTarget(t *testing.T) {
+	if err := checkTargetKeyStateClean("banana", "", nil); err == nil {
+		t.Error("expected error for unknown target")
+	}
+}
+
+func TestNewKeySourceByName_UnknownReturnsError(t *testing.T) {
+	if _, err := newKeySourceByName("banana", "/tmp", nil); err == nil {
+		t.Error("expected error for unknown source")
+	}
+}
+
+func TestInitializeTargetKeySource_UnknownReturnsError(t *testing.T) {
+	if err := initializeTargetKeySource(nil, "banana"); err == nil {
+		t.Error("expected error for unknown target")
+	}
+}
+
+func TestUnusedKeyStateNote(t *testing.T) {
+	dir := t.TempDir()
+	if got := unusedKeyStateNote("banana", dir); got != "" {
+		t.Errorf("unknown source should yield empty note, got %q", got)
+	}
+	if got := unusedKeyStateNote("keychain", dir); !strings.Contains(got, encKeyService) {
+		t.Errorf("keychain note should mention service name, got %q", got)
+	}
+	if got := unusedKeyStateNote("password", dir); got != "" {
+		t.Errorf("password note with no sidecar should be empty, got %q", got)
+	}
+	sidecar := filepath.Join(dir, "passwords.key")
+	if err := os.WriteFile(sidecar, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := unusedKeyStateNote("password", dir); !strings.Contains(got, sidecar) {
+		t.Errorf("password note with sidecar should mention path, got %q", got)
+	}
+}
+
+func TestPromptYesNo(t *testing.T) {
+	cases := map[string]bool{
+		"y\n":     true,
+		"Y\n":     true,
+		"yes\n":   false,
+		"n\n":     false,
+		"\n":      false,
+		"":        false,
+		"  y  \n": true,
+	}
+	for input, want := range cases {
+		t.Run(strings.TrimSpace(input), func(t *testing.T) {
+			got, err := promptYesNo(strings.NewReader(input), new(bytes.Buffer), "")
+			if err != nil {
+				t.Fatalf("promptYesNo(%q): %v", input, err)
+			}
+			if got != want {
+				t.Errorf("promptYesNo(%q) = %v, want %v", input, got, want)
+			}
+		})
+	}
+}
+
+func TestCurrentKeySourceName(t *testing.T) {
+	t.Setenv("SESH_KEY_SOURCE", "")
+	if got := currentKeySourceName(); got != "keychain" {
+		t.Errorf("empty env should default to keychain, got %q", got)
+	}
+	t.Setenv("SESH_KEY_SOURCE", "password")
+	if got := currentKeySourceName(); got != "password" {
+		t.Errorf("explicit password not preserved, got %q", got)
 	}
 }

--- a/sesh/cmd/sesh/rekey_test.go
+++ b/sesh/cmd/sesh/rekey_test.go
@@ -52,37 +52,14 @@ func hexKey() []byte {
 	return []byte(strings.Repeat("ab", 32))
 }
 
-func rekeyTestApp() (*App, *bytes.Buffer) {
+func rekeyTestApp(stdin string) (*App, *bytes.Buffer) {
 	stderr := new(bytes.Buffer)
 	return &App{
+		Stdin:  strings.NewReader(stdin),
 		Stdout: new(bytes.Buffer),
 		Stderr: stderr,
 		Exit:   func(int) {},
 	}, stderr
-}
-
-// withStdin replaces os.Stdin with a pipe pre-loaded with input. Restoring
-// is the caller's responsibility via the returned func.
-func withStdin(t *testing.T, input string) func() {
-	t.Helper()
-	oldStdin := os.Stdin
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("create stdin pipe: %v", err)
-	}
-	os.Stdin = r
-	if _, err := w.Write([]byte(input)); err != nil {
-		t.Fatalf("write stdin: %v", err)
-	}
-	if err := w.Close(); err != nil {
-		t.Fatalf("close stdin writer: %v", err)
-	}
-	return func() {
-		os.Stdin = oldStdin
-		if cerr := r.Close(); cerr != nil {
-			t.Errorf("close stdin pipe: %v", cerr)
-		}
-	}
 }
 
 type kcMock struct {
@@ -217,7 +194,7 @@ func readEntriesViaKeychain(t *testing.T, env *rekeyTestEnv, kc keychain.Provide
 
 func TestRekey_RefusesIfBackendNotSqlite(t *testing.T) {
 	t.Setenv("SESH_BACKEND", "")
-	app, _ := rekeyTestApp()
+	app, _ := rekeyTestApp("")
 	err := runRekey(app, []string{"--to=password"}, nil)
 	if err == nil || !strings.Contains(err.Error(), "SESH_BACKEND=sqlite") {
 		t.Fatalf("expected SESH_BACKEND error, got %v", err)
@@ -226,7 +203,7 @@ func TestRekey_RefusesIfBackendNotSqlite(t *testing.T) {
 
 func TestRekey_RefusesIfTargetMissing(t *testing.T) {
 	t.Setenv("SESH_BACKEND", "sqlite")
-	app, _ := rekeyTestApp()
+	app, _ := rekeyTestApp("")
 	err := runRekey(app, []string{}, nil)
 	if err == nil || !strings.Contains(err.Error(), "--to") {
 		t.Fatalf("expected --to error, got %v", err)
@@ -235,7 +212,7 @@ func TestRekey_RefusesIfTargetMissing(t *testing.T) {
 
 func TestRekey_RefusesIfTargetInvalid(t *testing.T) {
 	t.Setenv("SESH_BACKEND", "sqlite")
-	app, _ := rekeyTestApp()
+	app, _ := rekeyTestApp("")
 	err := runRekey(app, []string{"--to=banana"}, nil)
 	if err == nil || !strings.Contains(err.Error(), "--to") {
 		t.Fatalf("expected --to validation error, got %v", err)
@@ -250,7 +227,7 @@ func TestRekey_RefusesIfSameSource(t *testing.T) {
 		"sesh-password/password/github/alice": "hunter2",
 	})
 
-	app, _ := rekeyTestApp()
+	app, _ := rekeyTestApp("")
 	err := runRekey(app, []string{"--to=password"}, nil)
 	if err == nil || !strings.Contains(err.Error(), "already using") {
 		t.Fatalf("expected already-using error, got %v", err)
@@ -259,7 +236,7 @@ func TestRekey_RefusesIfSameSource(t *testing.T) {
 
 func TestRekey_RefusesIfNoDatabase(t *testing.T) {
 	setupRekeyEnv(t)
-	app, _ := rekeyTestApp()
+	app, _ := rekeyTestApp("")
 	err := runRekey(app, []string{"--to=password"}, newKCMock(hexKey()))
 	if err == nil || !strings.Contains(err.Error(), "no database") {
 		t.Fatalf("expected no-database error, got %v", err)
@@ -277,7 +254,7 @@ func TestRekey_RefusesIfTargetSidecarExists(t *testing.T) {
 		t.Fatalf("pre-create sidecar: %v", err)
 	}
 
-	app, _ := rekeyTestApp()
+	app, _ := rekeyTestApp("")
 	err := runRekey(app, []string{"--to=password"}, kc)
 	if err == nil || !strings.Contains(err.Error(), "already exists") {
 		t.Fatalf("expected sidecar-exists error, got %v", err)
@@ -302,9 +279,8 @@ func TestRekey_KeychainToPassword(t *testing.T) {
 	populateKeychainStore(t, env, kc, entries)
 
 	t.Setenv("SESH_MASTER_PASSWORD", "new-master-password-1234")
-	defer withStdin(t, "y\n")()
 
-	app, stderr := rekeyTestApp()
+	app, stderr := rekeyTestApp("y\n")
 	if err := runRekey(app, []string{"--to=password"}, kc); err != nil {
 		t.Fatalf("runRekey: %v\nstderr:\n%s", err, stderr.String())
 	}
@@ -348,9 +324,8 @@ func TestRekey_PasswordToKeychain(t *testing.T) {
 	populatePasswordStore(t, env, entries)
 
 	kc := &kcMock{}
-	defer withStdin(t, "y\n")()
 
-	app, stderr := rekeyTestApp()
+	app, stderr := rekeyTestApp("y\n")
 	if err := runRekey(app, []string{"--to=keychain"}, kc); err != nil {
 		t.Fatalf("runRekey: %v\nstderr:\n%s", err, stderr.String())
 	}
@@ -405,9 +380,8 @@ func TestRekey_PreservesTimestamps(t *testing.T) {
 	}
 
 	t.Setenv("SESH_MASTER_PASSWORD", "new-master-password-1234")
-	defer withStdin(t, "y\n")()
 
-	app, _ := rekeyTestApp()
+	app, _ := rekeyTestApp("y\n")
 	if err := runRekey(app, []string{"--to=password"}, kc); err != nil {
 		t.Fatalf("runRekey: %v", err)
 	}
@@ -443,9 +417,8 @@ func TestRekey_EmptyDB(t *testing.T) {
 	populateKeychainStore(t, env, kc, nil)
 
 	t.Setenv("SESH_MASTER_PASSWORD", "new-master-password-1234")
-	defer withStdin(t, "y\n")()
 
-	app, stderr := rekeyTestApp()
+	app, stderr := rekeyTestApp("y\n")
 	if err := runRekey(app, []string{"--to=password"}, kc); err != nil {
 		t.Fatalf("runRekey: %v", err)
 	}
@@ -465,9 +438,8 @@ func TestRekey_CancelledLeavesNoChanges(t *testing.T) {
 	})
 
 	t.Setenv("SESH_MASTER_PASSWORD", "new-master-password-1234")
-	defer withStdin(t, "\n")()
 
-	app, stderr := rekeyTestApp()
+	app, stderr := rekeyTestApp("\n")
 	if err := runRekey(app, []string{"--to=password"}, kc); err != nil {
 		t.Fatalf("runRekey: %v", err)
 	}
@@ -495,13 +467,10 @@ func TestRekey_RoundtripKeychainPasswordKeychain(t *testing.T) {
 	populateKeychainStore(t, env, kc1, entries)
 
 	t.Setenv("SESH_MASTER_PASSWORD", "intermediate-password-1234")
-	restore := withStdin(t, "y\n")
-	app1, _ := rekeyTestApp()
+	app1, _ := rekeyTestApp("y\n")
 	if err := runRekey(app1, []string{"--to=password"}, kc1); err != nil {
-		restore()
 		t.Fatalf("first rekey: %v", err)
 	}
-	restore()
 
 	t.Setenv("SESH_KEY_SOURCE", "password")
 	if err := os.Remove(env.dbPath + rekeyBackupSuffix); err != nil {
@@ -509,13 +478,10 @@ func TestRekey_RoundtripKeychainPasswordKeychain(t *testing.T) {
 	}
 
 	kc2 := &kcMock{}
-	restore = withStdin(t, "y\n")
-	app2, _ := rekeyTestApp()
+	app2, _ := rekeyTestApp("y\n")
 	if err := runRekey(app2, []string{"--to=keychain"}, kc2); err != nil {
-		restore()
 		t.Fatalf("second rekey: %v", err)
 	}
-	restore()
 
 	services := []string{"sesh-password/password/github/alice", "sesh-totp/github"}
 	got := readEntriesViaKeychain(t, env, kc2, services)

--- a/sesh/cmd/sesh/rekey_test.go
+++ b/sesh/cmd/sesh/rekey_test.go
@@ -244,6 +244,28 @@ func TestRekey_RefusesIfNoDatabase(t *testing.T) {
 	}
 }
 
+func TestRekey_RefusesIfBackupPathExists(t *testing.T) {
+	env := setupRekeyEnv(t)
+	kc := newKCMock(hexKey())
+	populateKeychainStore(t, env, kc, map[string]string{
+		"sesh-password/password/github/alice": "hunter2",
+	})
+
+	if err := os.WriteFile(env.dbPath+rekeyBackupSuffix, []byte("stale"), 0o600); err != nil {
+		t.Fatalf("pre-create backup: %v", err)
+	}
+
+	app, _ := rekeyTestApp("")
+	err := runRekey(app, []string{"--to=password"}, kc)
+	if err == nil || !strings.Contains(err.Error(), "backup path") {
+		t.Fatalf("expected backup-path-exists error, got %v", err)
+	}
+
+	if _, err := os.Stat(env.sidecarPath); err == nil {
+		t.Errorf("sidecar should not exist after refusal")
+	}
+}
+
 func TestRekey_RefusesIfTargetSidecarExists(t *testing.T) {
 	env := setupRekeyEnv(t)
 	kc := newKCMock(hexKey())

--- a/sesh/cmd/sesh/rekey_test.go
+++ b/sesh/cmd/sesh/rekey_test.go
@@ -1,0 +1,527 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/bashhack/sesh/internal/database"
+	"github.com/bashhack/sesh/internal/keychain"
+)
+
+type rekeyTestEnv struct {
+	tmpDir      string
+	dataDir     string
+	dbPath      string
+	sidecarPath string
+	account     string
+}
+
+func setupRekeyEnv(t *testing.T) *rekeyTestEnv {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", filepath.Join(tmp, "xdg"))
+	t.Setenv("SESH_BACKEND", "sqlite")
+	t.Setenv("SESH_KEY_SOURCE", "")
+	t.Setenv("SESH_MASTER_PASSWORD", "")
+
+	dbPath, err := database.DefaultDBPath()
+	if err != nil {
+		t.Fatalf("DefaultDBPath: %v", err)
+	}
+	dataDir := filepath.Dir(dbPath)
+	u, err := user.Current()
+	if err != nil {
+		t.Fatalf("user.Current: %v", err)
+	}
+	return &rekeyTestEnv{
+		tmpDir:      tmp,
+		dataDir:     dataDir,
+		dbPath:      dbPath,
+		sidecarPath: filepath.Join(dataDir, "passwords.key"),
+		account:     u.Username,
+	}
+}
+
+func hexKey() []byte {
+	return []byte(strings.Repeat("ab", 32))
+}
+
+func rekeyTestApp() (*App, *bytes.Buffer) {
+	stderr := new(bytes.Buffer)
+	return &App{
+		Stdout: new(bytes.Buffer),
+		Stderr: stderr,
+		Exit:   func(int) {},
+	}, stderr
+}
+
+// withStdin replaces os.Stdin with a pipe pre-loaded with input. Restoring
+// is the caller's responsibility via the returned func.
+func withStdin(t *testing.T, input string) func() {
+	t.Helper()
+	oldStdin := os.Stdin
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stdin pipe: %v", err)
+	}
+	os.Stdin = r
+	if _, err := w.Write([]byte(input)); err != nil {
+		t.Fatalf("write stdin: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close stdin writer: %v", err)
+	}
+	return func() {
+		os.Stdin = oldStdin
+		if cerr := r.Close(); cerr != nil {
+			t.Errorf("close stdin pipe: %v", cerr)
+		}
+	}
+}
+
+type kcMock struct {
+	stored []byte
+	mu     sync.Mutex
+}
+
+func newKCMock(stored []byte) *kcMock {
+	if stored == nil {
+		return &kcMock{}
+	}
+	return &kcMock{stored: append([]byte{}, stored...)}
+}
+
+func (m *kcMock) GetSecret(_, _ string) ([]byte, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.stored == nil {
+		return nil, keychain.ErrNotFound
+	}
+	return append([]byte{}, m.stored...), nil
+}
+
+func (m *kcMock) SetSecret(_, _ string, secret []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.stored = append([]byte{}, secret...)
+	return nil
+}
+
+func (m *kcMock) GetSecretString(_, _ string) (string, error)            { return "", nil }
+func (m *kcMock) SetSecretString(_, _, _ string) error                   { return nil }
+func (m *kcMock) GetMFASerialBytes(_, _ string) ([]byte, error)          { return nil, keychain.ErrNotFound }
+func (m *kcMock) ListEntries(_ string) ([]keychain.KeychainEntry, error) { return nil, nil }
+func (m *kcMock) SetDescription(_, _, _ string) error                    { return nil }
+func (m *kcMock) DeleteEntry(_, _ string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.stored = nil
+	return nil
+}
+
+func populateKeychainStore(t *testing.T, env *rekeyTestEnv, kc keychain.Provider, entries map[string]string) {
+	t.Helper()
+	ks := database.NewKeychainSource(kc, env.account)
+	store, err := database.Open(env.dbPath, ks)
+	if err != nil {
+		t.Fatalf("open store for seeding: %v", err)
+	}
+	defer func() {
+		if cerr := store.Close(); cerr != nil {
+			t.Fatalf("close seed store: %v", cerr)
+		}
+	}()
+	if err := store.InitKeyMetadata(); err != nil {
+		t.Fatalf("init key metadata: %v", err)
+	}
+	for service, secret := range entries {
+		if err := store.SetSecret(env.account, service, []byte(secret)); err != nil {
+			t.Fatalf("seed entry %s: %v", service, err)
+		}
+	}
+}
+
+func populatePasswordStore(t *testing.T, env *rekeyTestEnv, entries map[string]string) {
+	t.Helper()
+	ks := database.NewMasterPasswordSource(env.dataDir, promptMasterPassword)
+	store, err := database.Open(env.dbPath, ks)
+	if err != nil {
+		t.Fatalf("open store for seeding: %v", err)
+	}
+	defer func() {
+		if cerr := store.Close(); cerr != nil {
+			t.Fatalf("close seed store: %v", cerr)
+		}
+	}()
+	if err := store.InitKeyMetadata(); err != nil {
+		t.Fatalf("init key metadata: %v", err)
+	}
+	for service, secret := range entries {
+		if err := store.SetSecret(env.account, service, []byte(secret)); err != nil {
+			t.Fatalf("seed entry %s: %v", service, err)
+		}
+	}
+}
+
+func readEntriesViaPassword(t *testing.T, env *rekeyTestEnv, services []string) map[string]string {
+	t.Helper()
+	ks := database.NewMasterPasswordSource(env.dataDir, promptMasterPassword)
+	store, err := database.Open(env.dbPath, ks)
+	if err != nil {
+		t.Fatalf("open store for verify: %v", err)
+	}
+	defer func() {
+		if cerr := store.Close(); cerr != nil {
+			t.Fatalf("close verify store: %v", cerr)
+		}
+	}()
+	out := make(map[string]string, len(services))
+	for _, svc := range services {
+		b, err := store.GetSecret(env.account, svc)
+		if err != nil {
+			t.Fatalf("get entry %s: %v", svc, err)
+		}
+		out[svc] = string(b)
+	}
+	return out
+}
+
+func readEntriesViaKeychain(t *testing.T, env *rekeyTestEnv, kc keychain.Provider, services []string) map[string]string {
+	t.Helper()
+	ks := database.NewKeychainSource(kc, env.account)
+	store, err := database.Open(env.dbPath, ks)
+	if err != nil {
+		t.Fatalf("open store for verify: %v", err)
+	}
+	defer func() {
+		if cerr := store.Close(); cerr != nil {
+			t.Fatalf("close verify store: %v", cerr)
+		}
+	}()
+	out := make(map[string]string, len(services))
+	for _, svc := range services {
+		b, err := store.GetSecret(env.account, svc)
+		if err != nil {
+			t.Fatalf("get entry %s: %v", svc, err)
+		}
+		out[svc] = string(b)
+	}
+	return out
+}
+
+func TestRekey_RefusesIfBackendNotSqlite(t *testing.T) {
+	t.Setenv("SESH_BACKEND", "")
+	app, _ := rekeyTestApp()
+	err := runRekey(app, []string{"--to=password"}, nil)
+	if err == nil || !strings.Contains(err.Error(), "SESH_BACKEND=sqlite") {
+		t.Fatalf("expected SESH_BACKEND error, got %v", err)
+	}
+}
+
+func TestRekey_RefusesIfTargetMissing(t *testing.T) {
+	t.Setenv("SESH_BACKEND", "sqlite")
+	app, _ := rekeyTestApp()
+	err := runRekey(app, []string{}, nil)
+	if err == nil || !strings.Contains(err.Error(), "--to") {
+		t.Fatalf("expected --to error, got %v", err)
+	}
+}
+
+func TestRekey_RefusesIfTargetInvalid(t *testing.T) {
+	t.Setenv("SESH_BACKEND", "sqlite")
+	app, _ := rekeyTestApp()
+	err := runRekey(app, []string{"--to=banana"}, nil)
+	if err == nil || !strings.Contains(err.Error(), "--to") {
+		t.Fatalf("expected --to validation error, got %v", err)
+	}
+}
+
+func TestRekey_RefusesIfSameSource(t *testing.T) {
+	env := setupRekeyEnv(t)
+	t.Setenv("SESH_KEY_SOURCE", "password")
+	t.Setenv("SESH_MASTER_PASSWORD", "test-password-1234")
+	populatePasswordStore(t, env, map[string]string{
+		"sesh-password/password/github/alice": "hunter2",
+	})
+
+	app, _ := rekeyTestApp()
+	err := runRekey(app, []string{"--to=password"}, nil)
+	if err == nil || !strings.Contains(err.Error(), "already using") {
+		t.Fatalf("expected already-using error, got %v", err)
+	}
+}
+
+func TestRekey_RefusesIfNoDatabase(t *testing.T) {
+	setupRekeyEnv(t)
+	app, _ := rekeyTestApp()
+	err := runRekey(app, []string{"--to=password"}, newKCMock(hexKey()))
+	if err == nil || !strings.Contains(err.Error(), "no database") {
+		t.Fatalf("expected no-database error, got %v", err)
+	}
+}
+
+func TestRekey_RefusesIfTargetSidecarExists(t *testing.T) {
+	env := setupRekeyEnv(t)
+	kc := newKCMock(hexKey())
+	populateKeychainStore(t, env, kc, map[string]string{
+		"sesh-password/password/github/alice": "hunter2",
+	})
+
+	if err := os.WriteFile(env.sidecarPath, []byte(`{"version":1}`), 0o600); err != nil {
+		t.Fatalf("pre-create sidecar: %v", err)
+	}
+
+	app, _ := rekeyTestApp()
+	err := runRekey(app, []string{"--to=password"}, kc)
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("expected sidecar-exists error, got %v", err)
+	}
+
+	if _, err := os.Stat(env.dbPath); err != nil {
+		t.Fatalf("source DB should still exist: %v", err)
+	}
+	if _, err := os.Stat(env.dbPath + rekeyBackupSuffix); err == nil {
+		t.Fatalf("backup file should not exist on refusal")
+	}
+}
+
+func TestRekey_KeychainToPassword(t *testing.T) {
+	env := setupRekeyEnv(t)
+	kc := newKCMock(hexKey())
+	entries := map[string]string{
+		"sesh-password/password/github/alice": "hunter2",
+		"sesh-totp/github":                    "JBSWY3DPEHPK3PXP",
+		"sesh-password/api_key/stripe/admin":  "sk_test_xyz",
+	}
+	populateKeychainStore(t, env, kc, entries)
+
+	t.Setenv("SESH_MASTER_PASSWORD", "new-master-password-1234")
+	defer withStdin(t, "y\n")()
+
+	app, stderr := rekeyTestApp()
+	if err := runRekey(app, []string{"--to=password"}, kc); err != nil {
+		t.Fatalf("runRekey: %v\nstderr:\n%s", err, stderr.String())
+	}
+
+	if !strings.Contains(stderr.String(), "Rekeyed 3 entries") {
+		t.Errorf("stderr missing rekey summary:\n%s", stderr.String())
+	}
+	if _, err := os.Stat(env.dbPath + rekeyBackupSuffix); err != nil {
+		t.Errorf("backup DB missing: %v", err)
+	}
+	if _, err := os.Stat(env.sidecarPath); err != nil {
+		t.Errorf("new sidecar missing: %v", err)
+	}
+	// Old keychain entry left in place — the design contract.
+	if existing, err := kc.GetSecret(env.account, encKeyService); err != nil {
+		t.Errorf("old keychain entry should still exist: %v", err)
+	} else if len(existing) != 64 {
+		t.Errorf("old keychain entry hex length = %d, want 64", len(existing))
+	}
+
+	services := make([]string, 0, len(entries))
+	for s := range entries {
+		services = append(services, s)
+	}
+	got := readEntriesViaPassword(t, env, services)
+	for svc, want := range entries {
+		if got[svc] != want {
+			t.Errorf("entry %s = %q, want %q", svc, got[svc], want)
+		}
+	}
+}
+
+func TestRekey_PasswordToKeychain(t *testing.T) {
+	env := setupRekeyEnv(t)
+	t.Setenv("SESH_KEY_SOURCE", "password")
+	t.Setenv("SESH_MASTER_PASSWORD", "old-master-password-1234")
+	entries := map[string]string{
+		"sesh-password/password/github/alice": "hunter2",
+		"sesh-totp/github":                    "JBSWY3DPEHPK3PXP",
+	}
+	populatePasswordStore(t, env, entries)
+
+	kc := &kcMock{}
+	defer withStdin(t, "y\n")()
+
+	app, stderr := rekeyTestApp()
+	if err := runRekey(app, []string{"--to=keychain"}, kc); err != nil {
+		t.Fatalf("runRekey: %v\nstderr:\n%s", err, stderr.String())
+	}
+
+	if !strings.Contains(stderr.String(), "Rekeyed 2 entries") {
+		t.Errorf("stderr missing rekey summary:\n%s", stderr.String())
+	}
+	if _, err := os.Stat(env.sidecarPath); err != nil {
+		t.Errorf("old sidecar should still exist: %v", err)
+	}
+	if kc.stored == nil {
+		t.Errorf("new keychain entry not stored")
+	} else if len(kc.stored) != 64 {
+		t.Errorf("new keychain entry hex length = %d, want 64", len(kc.stored))
+	}
+	if _, err := os.Stat(env.dbPath + rekeyBackupSuffix); err != nil {
+		t.Errorf("backup DB missing: %v", err)
+	}
+
+	services := []string{"sesh-password/password/github/alice", "sesh-totp/github"}
+	got := readEntriesViaKeychain(t, env, kc, services)
+	for svc, want := range entries {
+		if got[svc] != want {
+			t.Errorf("entry %s = %q, want %q", svc, got[svc], want)
+		}
+	}
+}
+
+func TestRekey_PreservesTimestamps(t *testing.T) {
+	env := setupRekeyEnv(t)
+	kc := newKCMock(hexKey())
+	populateKeychainStore(t, env, kc, map[string]string{
+		"sesh-password/password/github/alice": "hunter2",
+	})
+
+	srcKS := database.NewKeychainSource(kc, env.account)
+	srcStore, err := database.Open(env.dbPath, srcKS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srcEntries, err := srcStore.ListEntries("sesh-password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(srcEntries) != 1 {
+		t.Fatalf("setup: expected 1 entry, got %d", len(srcEntries))
+	}
+	wantCreated := srcEntries[0].CreatedAt
+	wantUpdated := srcEntries[0].UpdatedAt
+	if err := srcStore.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("SESH_MASTER_PASSWORD", "new-master-password-1234")
+	defer withStdin(t, "y\n")()
+
+	app, _ := rekeyTestApp()
+	if err := runRekey(app, []string{"--to=password"}, kc); err != nil {
+		t.Fatalf("runRekey: %v", err)
+	}
+
+	mps := database.NewMasterPasswordSource(env.dataDir, promptMasterPassword)
+	store, err := database.Open(env.dbPath, mps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if cerr := store.Close(); cerr != nil {
+			t.Errorf("close verify store: %v", cerr)
+		}
+	}()
+	postEntries, err := store.ListEntries("sesh-password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(postEntries) != 1 {
+		t.Fatalf("post-rekey: expected 1 entry, got %d", len(postEntries))
+	}
+	if !postEntries[0].CreatedAt.Equal(wantCreated) {
+		t.Errorf("CreatedAt = %v, want %v", postEntries[0].CreatedAt, wantCreated)
+	}
+	if !postEntries[0].UpdatedAt.Equal(wantUpdated) {
+		t.Errorf("UpdatedAt = %v, want %v", postEntries[0].UpdatedAt, wantUpdated)
+	}
+}
+
+func TestRekey_EmptyDB(t *testing.T) {
+	env := setupRekeyEnv(t)
+	kc := newKCMock(hexKey())
+	populateKeychainStore(t, env, kc, nil)
+
+	t.Setenv("SESH_MASTER_PASSWORD", "new-master-password-1234")
+	defer withStdin(t, "y\n")()
+
+	app, stderr := rekeyTestApp()
+	if err := runRekey(app, []string{"--to=password"}, kc); err != nil {
+		t.Fatalf("runRekey: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "Rekeyed 0 entries") {
+		t.Errorf("stderr missing zero-entry summary:\n%s", stderr.String())
+	}
+	if _, err := os.Stat(env.sidecarPath); err != nil {
+		t.Errorf("new sidecar should be created even for empty DB: %v", err)
+	}
+}
+
+func TestRekey_CancelledLeavesNoChanges(t *testing.T) {
+	env := setupRekeyEnv(t)
+	kc := newKCMock(hexKey())
+	populateKeychainStore(t, env, kc, map[string]string{
+		"sesh-password/password/github/alice": "hunter2",
+	})
+
+	t.Setenv("SESH_MASTER_PASSWORD", "new-master-password-1234")
+	defer withStdin(t, "\n")()
+
+	app, stderr := rekeyTestApp()
+	if err := runRekey(app, []string{"--to=password"}, kc); err != nil {
+		t.Fatalf("runRekey: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "Rekey cancelled") {
+		t.Errorf("stderr missing cancel message:\n%s", stderr.String())
+	}
+	if _, err := os.Stat(env.sidecarPath); err == nil {
+		t.Errorf("sidecar should not exist after cancellation")
+	}
+	if _, err := os.Stat(env.dbPath + rekeyBackupSuffix); err == nil {
+		t.Errorf("backup should not exist after cancellation")
+	}
+	if _, err := os.Stat(env.dbPath + rekeyDestSuffix); err == nil {
+		t.Errorf(".new DB should not exist after cancellation")
+	}
+}
+
+func TestRekey_RoundtripKeychainPasswordKeychain(t *testing.T) {
+	env := setupRekeyEnv(t)
+	kc1 := newKCMock(hexKey())
+	entries := map[string]string{
+		"sesh-password/password/github/alice": "hunter2",
+		"sesh-totp/github":                    "JBSWY3DPEHPK3PXP",
+	}
+	populateKeychainStore(t, env, kc1, entries)
+
+	t.Setenv("SESH_MASTER_PASSWORD", "intermediate-password-1234")
+	restore := withStdin(t, "y\n")
+	app1, _ := rekeyTestApp()
+	if err := runRekey(app1, []string{"--to=password"}, kc1); err != nil {
+		restore()
+		t.Fatalf("first rekey: %v", err)
+	}
+	restore()
+
+	t.Setenv("SESH_KEY_SOURCE", "password")
+	if err := os.Remove(env.dbPath + rekeyBackupSuffix); err != nil {
+		t.Fatalf("clean step-1 backup: %v", err)
+	}
+
+	kc2 := &kcMock{}
+	restore = withStdin(t, "y\n")
+	app2, _ := rekeyTestApp()
+	if err := runRekey(app2, []string{"--to=keychain"}, kc2); err != nil {
+		restore()
+		t.Fatalf("second rekey: %v", err)
+	}
+	restore()
+
+	services := []string{"sesh-password/password/github/alice", "sesh-totp/github"}
+	got := readEntriesViaKeychain(t, env, kc2, services)
+	for svc, want := range entries {
+		if got[svc] != want {
+			t.Errorf("entry %s after roundtrip = %q, want %q", svc, got[svc], want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes the keychain-dependency gap for `SESH_BACKEND=sqlite`. Before this branch, even SQLite mode pulled its master encryption key from the macOS Keychain — switching to SQLite still meant depending on the Keychain. After this branch, SQLite mode is fully self-contained and cross-platform.

## What's in this PR

**New: master password key source.** `SESH_KEY_SOURCE=password` derives the master encryption key from a user-supplied passphrase via Argon2id (`t=3, m=64 MiB, p=4`). KDF salt + parameters + a verification blob (AES-256-GCM-encrypted known constant) are stored in a sidecar file `passwords.key` (0600) next to the SQLite DB. No keychain involvement.

**New: encrypted export / import.** `--format encrypted` produces a portable AES-256-GCM + Argon2id envelope. The recipient password decrypts it regardless of which key source the original DB used.

**New: `sesh --rekey --to <keychain|password>`.** Re-encrypts every entry under a different key source and atomically swaps the result into place. Sibling-DB + atomic-rename pattern; original preserved at ` <dbPath>.pre-rekey`. Refuses if the target key state already exists. Old key state (sidecar or keychain entry) deliberately left in place for rollback.

**Migration upgrade.** `migration.Migrate` now type-asserts the destination for `keychain.TimestampedStore` and preserves `created_at` / `updated_at` when supported. Strict superset of prior behaviour — sources without timestamps still work because zero-value timestamps fall back to the current time.

**Hardening.** Bounds-validation of attacker-controlled Argon2id params (memory ≤ 1 GiB, time ≤ 10, threads ≤ 16, key_len == 32) on the sidecar and on encrypted-export envelopes. Atomic temp-file + rename for sidecar writes. Salt and verify-blob length sanity checks short-circuit before Argon2id when reading a malformed sidecar. Fixed a CRITICAL deferred-zero no-op bug.

**Security fix.** `--list` and `--delete` previously didn't consult the `KeySource` (they only touch metadata), letting an attacker with filesystem access enumerate and delete entries without the master password. Eager `GetEncryptionKey()` in `buildKeySource` for password mode, with an in-memory key cache cleared by `Close()`.

**Concurrency fix.** Two parallel `sesh` invocations on a fresh install would otherwise race the sidecar init, generate independent salts, and silently lock the loser out. Fixed via `syscall.Flock` on `<dataDir>/passwords.key.lock`. Tests verified to fail without the fix and pass with it, both in-process (4 goroutines) and multi-process (4 child binaries).

**Plumbing.** `App.Stdin io.Reader` field added so `runRekey` and `runMigrate` can read confirmation input from a test-injectable source instead of `os.Stdin`.

**Docs.** `USAGE_AND_CONFIGURATION.md` covers the master password mode, encrypted export, and rekey command. `SECURITY_MODEL.md` documents the threat model, KDF parameters, password length floor, and rekey's atomic semantics.

## Test plan

- [x] `make pre-commit` clean
- [x] `go test ./... -count=1` passes
- [x] Multi-process flock test (`TestMasterPasswordSource_ConcurrentFirstRunMultiProcess`) verified to fail without the flock fix and pass with it
- [x] Manual smoke: keychain → password → keychain roundtrip, all 6 entries decrypt correctly under each mode, refusal cases (target sidecar exists, target keychain entry exists, wrong master password) all surface cleanly with no DB mutation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Password-based SQLite master-key mode (SESH_KEY_SOURCE=password) with non-interactive unlock (SESH_MASTER_PASSWORD)
  * Encrypted export/import backups (`--format encrypted`) protected by a password
  * New atomic, recoverable `rekey` command to migrate key sources while preserving entry timestamps
  * App stdin injection for scripted prompts; improved clearing of in-memory key material on store close

* **Documentation**
  * Updated README, architecture, security, and usage docs covering key-source modes, sidecar behavior, encrypted export format, and rekey workflow

* **Tests**
  * Expanded tests for master-password mode, encrypted export/import, rekey, and timestamp-preserving migrations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->