### PR TITLE
Add wrong-password retry loop for interactive master password unlock

### DIFF
--- a/internal/database/master_password.go
+++ b/internal/database/master_password.go
@@ -62,15 +62,48 @@ type MasterPasswordSource struct {
 	cachedKey  []byte
 	mu         sync.Mutex
 	cacheEpoch uint64
+	// maxAttempts is the number of password prompts allowed in the unlock
+	// loop. Defaults to 1 (no retry); callers that know they're talking to
+	// an interactive TTY set this higher via WithMaxAttempts.
+	maxAttempts int
+}
+
+// Option configures a MasterPasswordSource. Use with NewMasterPasswordSource.
+type Option func(*MasterPasswordSource)
+
+// WithMaxAttempts sets the maximum number of password prompts the unlock
+// loop will issue before giving up. Values < 1 are clamped to 1. Only
+// wrong-password failures are retried; sidecar/IO errors fail immediately.
+//
+// The prompt callback must produce fresh user input on each invocation —
+// a callback that returns a constant value (e.g., one backed by an env
+// var) will derive the same wrong key N times and waste ~N × Argon2id
+// cycles before failing. The CLI gates this via resolvePasswordPrompt in
+// main.go, which only marks a prompt interactive when it actually reads
+// fresh bytes; direct callers must apply the same discipline.
+//
+// Only affects unlock(); first-run create+confirm always runs once.
+func WithMaxAttempts(n int) Option {
+	return func(s *MasterPasswordSource) {
+		if n < 1 {
+			n = 1
+		}
+		s.maxAttempts = n
+	}
 }
 
 // NewMasterPasswordSource creates a MasterPasswordSource that stores its
 // sidecar in dataDir (typically the same directory as the SQLite DB).
-func NewMasterPasswordSource(dataDir string, prompt PasswordPromptFunc) *MasterPasswordSource {
-	return &MasterPasswordSource{
-		dataDir:    dataDir,
-		promptFunc: prompt,
+func NewMasterPasswordSource(dataDir string, prompt PasswordPromptFunc, opts ...Option) *MasterPasswordSource {
+	s := &MasterPasswordSource{
+		dataDir:     dataDir,
+		promptFunc:  prompt,
+		maxAttempts: 1,
 	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
 }
 
 // Close zeroes and releases the cached key. Safe to call multiple times and
@@ -181,17 +214,29 @@ func (s *MasterPasswordSource) initializeLocked() ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open sidecar lock: %w", err)
 	}
-	defer func() {
+	released := false
+	release := func() {
+		if released {
+			return
+		}
+		released = true
 		if cerr := lockFile.Close(); cerr != nil {
 			fmt.Fprintf(os.Stderr, "warning: release sidecar lock: %v\n", cerr)
 		}
-	}()
+	}
+	defer release()
 	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX); err != nil {
 		return nil, fmt.Errorf("acquire sidecar lock: %w", err)
 	}
 
 	switch _, err := os.Stat(s.sidecarPath()); {
 	case err == nil:
+		// The flock's job was to serialize sidecar creation; with the
+		// sidecar already in place, drop it before falling into unlock()
+		// — the retry loop there can block for minutes on an interactive
+		// prompt and would otherwise stall any third concurrent invocation
+		// arriving at the lock.
+		release()
 		return s.unlock()
 	case os.IsNotExist(err):
 		return s.initialize()
@@ -297,23 +342,38 @@ func (s *MasterPasswordSource) unlock() ([]byte, error) {
 		return nil, fmt.Errorf("sidecar verify blob too short: %d bytes", len(verifyBlob))
 	}
 
-	pw, err := s.promptFunc("Master password: ")
-	if err != nil {
-		return nil, fmt.Errorf("read password: %w", err)
-	}
-	defer secure.SecureZeroBytes(pw)
+	attempts := max(s.maxAttempts, 1)
 
-	key := DeriveKey(pw, salt, data.Params)
+	for i := range attempts {
+		// First attempt uses the bare prompt; later attempts prepend a
+		// retry message so the prompt itself carries the "try again"
+		// signal without coupling this package to a stderr writer.
+		prompt := "Master password: "
+		if i > 0 {
+			prompt = fmt.Sprintf("Wrong password, try again (%d/%d). Master password: ", i+1, attempts)
+		}
 
-	// AES-GCM authentication is what guarantees "this plaintext was
-	// produced by encryption under this key" — a successful Decrypt is
-	// already proof of the right master password.
-	if _, err := Decrypt(key, verifyBlob); err != nil {
+		pw, err := s.promptFunc(prompt)
+		if err != nil {
+			return nil, fmt.Errorf("read password: %w", err)
+		}
+
+		key := DeriveKey(pw, salt, data.Params)
+		secure.SecureZeroBytes(pw)
+
+		// AES-GCM authentication is what guarantees "this plaintext was
+		// produced by encryption under this key" — a successful Decrypt is
+		// already proof of the right master password.
+		if _, err := Decrypt(key, verifyBlob); err == nil {
+			return key, nil
+		}
 		secure.SecureZeroBytes(key)
+	}
+
+	if attempts == 1 {
 		return nil, fmt.Errorf("wrong master password")
 	}
-
-	return key, nil
+	return nil, fmt.Errorf("wrong master password (after %d attempts)", attempts)
 }
 
 func (s *MasterPasswordSource) writeSidecar(data sidecarData) error {

--- a/internal/database/master_password_test.go
+++ b/internal/database/master_password_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
@@ -438,5 +439,192 @@ func TestMasterPasswordSource_SidecarHasNoSecrets(t *testing.T) {
 
 	if bytes.Contains(b, []byte(password)) {
 		t.Fatal("sidecar contains the master password in plaintext")
+	}
+}
+
+// seedSidecar creates a sidecar at dir whose master password is "right-one"
+// so retry-loop tests can drive unlock() directly without re-prompting twice
+// for the create+confirm flow.
+func seedSidecar(t *testing.T, dir string) {
+	t.Helper()
+	src := NewMasterPasswordSource(dir, staticPrompt("right-one", "right-one"))
+	defer src.Close()
+	key, err := src.GetEncryptionKey()
+	if err != nil {
+		t.Fatalf("seed sidecar: %v", err)
+	}
+	secure.SecureZeroBytes(key)
+}
+
+func TestMasterPasswordSource_RetriesWrongPasswordUntilCorrect(t *testing.T) {
+	dir := t.TempDir()
+	seedSidecar(t, dir)
+
+	var seenPrompts []string
+	prompt := func(p string) ([]byte, error) {
+		seenPrompts = append(seenPrompts, p)
+		switch len(seenPrompts) {
+		case 1:
+			return []byte("wrong-1"), nil
+		case 2:
+			return []byte("wrong-2"), nil
+		default:
+			return []byte("right-one"), nil
+		}
+	}
+
+	src := NewMasterPasswordSource(dir, prompt, WithMaxAttempts(3))
+	defer src.Close()
+
+	key, err := src.GetEncryptionKey()
+	if err != nil {
+		t.Fatalf("expected success on 3rd attempt: %v", err)
+	}
+	secure.SecureZeroBytes(key)
+	if len(seenPrompts) != 3 {
+		t.Fatalf("expected 3 prompts, got %d", len(seenPrompts))
+	}
+	// The retry-message contract is the user-visible signal that a
+	// previous attempt was wrong — assert it actually shows up in the
+	// prompt string (not just that we re-prompted).
+	if !strings.Contains(seenPrompts[1], "Wrong password") || !strings.Contains(seenPrompts[1], "(2/3)") {
+		t.Errorf("2nd prompt %q should announce the retry with (2/3)", seenPrompts[1])
+	}
+	if !strings.Contains(seenPrompts[2], "(3/3)") {
+		t.Errorf("3rd prompt %q should be marked (3/3)", seenPrompts[2])
+	}
+
+	// Cache-after-retry: a second GetEncryptionKey must hit the cache
+	// and not re-prompt, even though the successful unlock came on a
+	// non-first attempt.
+	key2, err := src.GetEncryptionKey()
+	if err != nil {
+		t.Fatalf("second GetEncryptionKey: %v", err)
+	}
+	secure.SecureZeroBytes(key2)
+	if len(seenPrompts) != 3 {
+		t.Errorf("cache should suppress re-prompt; got %d total prompts", len(seenPrompts))
+	}
+}
+
+func TestMasterPasswordSource_FailsAfterMaxAttempts(t *testing.T) {
+	dir := t.TempDir()
+	seedSidecar(t, dir)
+
+	prompts := 0
+	prompt := func(_ string) ([]byte, error) {
+		prompts++
+		return []byte("always-wrong"), nil
+	}
+
+	src := NewMasterPasswordSource(dir, prompt, WithMaxAttempts(3))
+	_, err := src.GetEncryptionKey()
+	if err == nil {
+		t.Fatal("expected error after exhausting attempts")
+	}
+	if !strings.Contains(err.Error(), "wrong master password") {
+		t.Errorf("error %q does not mention wrong password", err.Error())
+	}
+	// Multi-attempt failures surface the budget so logs/users can tell
+	// "they typed it wrong N times" from "single-shot non-interactive fail".
+	if !strings.Contains(err.Error(), "after 3 attempts") {
+		t.Errorf("error %q should report the attempt count", err.Error())
+	}
+	if prompts != 3 {
+		t.Errorf("expected 3 prompts, got %d", prompts)
+	}
+}
+
+func TestMasterPasswordSource_DefaultsToSingleAttempt(t *testing.T) {
+	dir := t.TempDir()
+	seedSidecar(t, dir)
+
+	prompts := 0
+	prompt := func(_ string) ([]byte, error) {
+		prompts++
+		return []byte("wrong"), nil
+	}
+
+	src := NewMasterPasswordSource(dir, prompt)
+	_, err := src.GetEncryptionKey()
+	if err == nil {
+		t.Fatal("expected error for wrong password")
+	}
+	if prompts != 1 {
+		t.Errorf("expected 1 prompt without WithMaxAttempts, got %d", prompts)
+	}
+}
+
+func TestMasterPasswordSource_PromptErrorBreaksLoop(t *testing.T) {
+	dir := t.TempDir()
+	seedSidecar(t, dir)
+
+	prompts := 0
+	prompt := func(_ string) ([]byte, error) {
+		prompts++
+		if prompts == 1 {
+			return []byte("wrong"), nil
+		}
+		return nil, errors.New("stdin closed")
+	}
+
+	src := NewMasterPasswordSource(dir, prompt, WithMaxAttempts(5))
+	_, err := src.GetEncryptionKey()
+	if err == nil {
+		t.Fatal("expected error from prompt failure")
+	}
+	if !strings.Contains(err.Error(), "read password") {
+		t.Errorf("error %q should surface the prompt failure", err.Error())
+	}
+	if prompts != 2 {
+		t.Errorf("expected loop to stop on prompt error after 2 calls, got %d", prompts)
+	}
+}
+
+func TestMasterPasswordSource_NoRetryOnSidecarError(t *testing.T) {
+	dir := t.TempDir()
+	// Write a sidecar with an unsupported version so readSidecar fails
+	// before any prompt can fire. Confirms the retry loop doesn't run
+	// for non-password failures (acceptance criterion #3 in the roadmap).
+	bad := `{"version": 99, "algorithm": "argon2id", "salt": "", "verify": "", "params": {"time":3,"memory":65536,"threads":4,"key_len":32}}`
+	if err := os.WriteFile(filepath.Join(dir, sidecarFileName), []byte(bad), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	prompts := 0
+	prompt := func(_ string) ([]byte, error) {
+		prompts++
+		return []byte("anything"), nil
+	}
+
+	src := NewMasterPasswordSource(dir, prompt, WithMaxAttempts(3))
+	_, err := src.GetEncryptionKey()
+	if err == nil {
+		t.Fatal("expected error from corrupt sidecar")
+	}
+	if prompts != 0 {
+		t.Errorf("expected 0 prompts when sidecar is corrupt, got %d", prompts)
+	}
+}
+
+func TestWithMaxAttempts_ClampsBelowOne(t *testing.T) {
+	dir := t.TempDir()
+	seedSidecar(t, dir)
+
+	for _, n := range []int{0, -1, -100} {
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			prompts := 0
+			prompt := func(_ string) ([]byte, error) {
+				prompts++
+				return []byte("wrong"), nil
+			}
+			src := NewMasterPasswordSource(dir, prompt, WithMaxAttempts(n))
+			if _, err := src.GetEncryptionKey(); err == nil {
+				t.Fatal("expected error")
+			}
+			if prompts != 1 {
+				t.Errorf("WithMaxAttempts(%d) should clamp to 1, got %d prompts", n, prompts)
+			}
+		})
 	}
 }

--- a/sesh/cmd/sesh/main.go
+++ b/sesh/cmd/sesh/main.go
@@ -161,7 +161,7 @@ func openSQLiteStore() (*database.Store, error) {
 func buildKeySource(dataDir string) (database.KeySource, error) {
 	switch os.Getenv("SESH_KEY_SOURCE") {
 	case "password":
-		mps := database.NewMasterPasswordSource(dataDir, promptMasterPassword)
+		mps := resolvePasswordPrompt().newSource(dataDir)
 		// Eagerly unlock so every operation — including metadata-only reads
 		// like --list and --delete — requires the master password. Without
 		// this, the store would only prompt on decryption, letting an
@@ -188,13 +188,59 @@ func buildKeySource(dataDir string) (database.KeySource, error) {
 	}
 }
 
-// promptMasterPassword reads a password from the terminal without echo.
-// Checks SESH_MASTER_PASSWORD env var first to support non-interactive use.
-func promptMasterPassword(prompt string) ([]byte, error) {
-	if envPw := os.Getenv("SESH_MASTER_PASSWORD"); envPw != "" {
-		return []byte(envPw), nil
-	}
+// interactivePasswordAttempts is the retry budget for an interactive TTY
+// password prompt. Three is the conventional ssh/sudo limit — enough to
+// recover from a typo without spending real CPU on Argon2id derivations
+// against a clearly-wrong password.
+const interactivePasswordAttempts = 3
 
+// passwordPromptConfig pairs a prompt callback with a flag indicating
+// whether the prompt represents a live human at a terminal. The two are
+// resolved together so the retry-loop budget can never be applied to a
+// constant-output prompt (e.g. one backed by SESH_MASTER_PASSWORD), which
+// would just burn N × Argon2id deriving the same wrong key.
+type passwordPromptConfig struct {
+	prompt      database.PasswordPromptFunc
+	interactive bool
+}
+
+// resolvePasswordPrompt picks the prompt callback based on the runtime
+// environment, in priority order:
+//   - SESH_MASTER_PASSWORD set → constant-bytes prompt, never interactive
+//   - stdin is a TTY → terminal read, interactive
+//   - otherwise (piped stdin, scripts) → terminal read, but not interactive
+//     so retry stays disabled
+//
+// Reading the env var here is the single source of truth for "is the
+// password input live human input?" — the answer feeds both the prompt
+// itself and the retry budget.
+func resolvePasswordPrompt() passwordPromptConfig {
+	if envPw := os.Getenv("SESH_MASTER_PASSWORD"); envPw != "" {
+		return passwordPromptConfig{
+			prompt:      func(_ string) ([]byte, error) { return []byte(envPw), nil },
+			interactive: false,
+		}
+	}
+	return passwordPromptConfig{
+		prompt:      terminalPrompt,
+		interactive: term.IsTerminal(int(os.Stdin.Fd())),
+	}
+}
+
+// newSource constructs a MasterPasswordSource using this config's prompt
+// and only enables the retry budget when the prompt is interactive.
+func (c passwordPromptConfig) newSource(dataDir string) *database.MasterPasswordSource {
+	var opts []database.Option
+	if c.interactive {
+		opts = append(opts, database.WithMaxAttempts(interactivePasswordAttempts))
+	}
+	return database.NewMasterPasswordSource(dataDir, c.prompt, opts...)
+}
+
+// terminalPrompt reads a password from the controlling terminal without
+// echo. Does not consult SESH_MASTER_PASSWORD — that decision belongs to
+// resolvePasswordPrompt so the env-var policy lives in exactly one place.
+func terminalPrompt(prompt string) ([]byte, error) {
 	if _, err := fmt.Fprint(os.Stderr, prompt); err != nil {
 		return nil, err
 	}
@@ -203,7 +249,10 @@ func promptMasterPassword(prompt string) ([]byte, error) {
 	// error mask a real read error.
 	fmt.Fprintln(os.Stderr) //nolint:errcheck // see comment above
 	if err != nil {
-		return nil, fmt.Errorf("read password: %w", err)
+		// Don't re-wrap as "read password" — the caller (unlock) already
+		// adds that prefix, and double-wrapping produced
+		// "read password: read password: ..." in error output.
+		return nil, err
 	}
 	return pw, nil
 }

--- a/sesh/cmd/sesh/main_test.go
+++ b/sesh/cmd/sesh/main_test.go
@@ -782,3 +782,36 @@ func TestEnsureMasterKey_Concurrent(t *testing.T) {
 		t.Errorf("stored hex length = %d, want 64 (hex of 32 raw bytes)", len(kc.stored))
 	}
 }
+
+func TestResolvePasswordPrompt_EnvVarYieldsConstantNonInteractive(t *testing.T) {
+	// SESH_MASTER_PASSWORD short-circuits the terminal read with a
+	// constant-bytes prompt. Such a prompt cannot meaningfully retry —
+	// it would derive the same wrong key N times — so interactive must
+	// be false to keep the retry budget off.
+	t.Setenv("SESH_MASTER_PASSWORD", "secret-from-env")
+	cfg := resolvePasswordPrompt()
+	if cfg.interactive {
+		t.Error("env-var prompt must not be marked interactive")
+	}
+	pw, err := cfg.prompt("ignored")
+	if err != nil {
+		t.Fatalf("env-var prompt should not error: %v", err)
+	}
+	if string(pw) != "secret-from-env" {
+		t.Errorf("env-var prompt returned %q, want %q", pw, "secret-from-env")
+	}
+}
+
+func TestResolvePasswordPrompt_NonTTYIsTerminalPromptButNotInteractive(t *testing.T) {
+	// `go test` runs with stdin not attached to a terminal. We still pick
+	// the terminal-read prompt (so a TTY-bound caller would work), but
+	// interactive stays false — no retry budget for piped/scripted callers.
+	t.Setenv("SESH_MASTER_PASSWORD", "")
+	cfg := resolvePasswordPrompt()
+	if cfg.interactive {
+		t.Error("non-TTY stdin must not be marked interactive")
+	}
+	if cfg.prompt == nil {
+		t.Fatal("prompt callback should be set even when not interactive")
+	}
+}

--- a/sesh/cmd/sesh/rekey.go
+++ b/sesh/cmd/sesh/rekey.go
@@ -259,7 +259,7 @@ func currentKeySourceName() string {
 func newKeySourceByName(name, dataDir string, kc keychain.Provider) (database.KeySource, error) {
 	switch name {
 	case "password":
-		return database.NewMasterPasswordSource(dataDir, promptMasterPassword), nil
+		return resolvePasswordPrompt().newSource(dataDir), nil
 	case "keychain":
 		u, err := user.Current()
 		if err != nil {

--- a/sesh/cmd/sesh/rekey_test.go
+++ b/sesh/cmd/sesh/rekey_test.go
@@ -144,7 +144,7 @@ func populateKeychainStore(t *testing.T, env *rekeyTestEnv, kc keychain.Provider
 
 func populatePasswordStore(t *testing.T, env *rekeyTestEnv, entries map[string]string) {
 	t.Helper()
-	ks := database.NewMasterPasswordSource(env.dataDir, promptMasterPassword)
+	ks := resolvePasswordPrompt().newSource(env.dataDir)
 	store, err := database.Open(env.dbPath, ks)
 	if err != nil {
 		t.Fatalf("open store for seeding: %v", err)
@@ -166,7 +166,7 @@ func populatePasswordStore(t *testing.T, env *rekeyTestEnv, entries map[string]s
 
 func readEntriesViaPassword(t *testing.T, env *rekeyTestEnv, services []string) map[string]string {
 	t.Helper()
-	ks := database.NewMasterPasswordSource(env.dataDir, promptMasterPassword)
+	ks := resolvePasswordPrompt().newSource(env.dataDir)
 	store, err := database.Open(env.dbPath, ks)
 	if err != nil {
 		t.Fatalf("open store for verify: %v", err)
@@ -451,7 +451,7 @@ func TestRekey_PreservesTimestamps(t *testing.T) {
 		t.Fatalf("runRekey: %v", err)
 	}
 
-	mps := database.NewMasterPasswordSource(env.dataDir, promptMasterPassword)
+	mps := resolvePasswordPrompt().newSource(env.dataDir)
 	store, err := database.Open(env.dbPath, mps)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary
- Implements item 5 from `docs/MASTER_PASSWORD_ROADMAP.md` ("Wrong-password retry loop — DEFERRED"). Interactive sessions now get up to 3 unlock attempts before giving up; non-interactive contexts (piped stdin, scripts, `SESH_MASTER_PASSWORD` env var) keep the existing single-attempt fail-fast behavior.
- Adds a functional-options API (`Option` / `WithMaxAttempts`) on `MasterPasswordSource` so the library API stays backward-compatible at every call site that doesn't opt in.
- Consolidates `SESH_MASTER_PASSWORD` handling into a single `resolvePasswordPrompt` factory so the env-var check and the retry-budget decision share one source of truth — the "constant prompt + retry" footgun (would derive the same wrong key N times) is now structurally impossible to construct via the factory.
- Drive-by: removes a redundant `read password:` wrap in `terminalPrompt` that was producing doubled prefixes (`read password: read password: ...`) in error output.

## Acceptance criteria (from roadmap)
- [x] Interactive: 3 attempts before giving up, with "wrong password, try again (N/3)" between attempts.
- [x] Non-interactive (no TTY, or `SESH_MASTER_PASSWORD` set): single attempt, fail fast.
- [x] No timing-side-channel that distinguishes "wrong password" from "sidecar corrupt" — sidecar/IO errors fail before the loop entry point and never re-prompt.

## Notable design choices
- **Functional options over a constructor arg**: anticipates more knobs landing as deferred roadmap items (session/agent) materialize. Existing call sites stay untouched (variadic).
- **Retry message piggybacks on the prompt string** (`"Wrong password, try again (2/3). Master password: "`) rather than threading an `io.Writer` through the library. Keeps `internal/database` free of `os.Stderr` coupling.
- **Per-iteration `pw` zeroing is inline, not deferred** — a deferred zero in a loop would only fire on function return, leaking earlier-attempt password bytes for the lifetime of the loop.
- **Flock released before falling into `unlock()` in the first-run race path** — the flock's job is to serialize sidecar creation; once the sidecar exists, holding it through a 3-attempt human prompt would stall any third concurrent invocation for minutes.
- **Final error includes attempt count when > 1** (`wrong master password (after 3 attempts)`) so logs can distinguish "human typed wrong N times" from "non-interactive single-shot failure." Singular case keeps the original wording.

## Test plan
- [x] `go test ./...` — full suite passes.
- [x] `golangci-lint run ./...` — clean.
- [x] Manual smoke test in fresh `HOME` with `SESH_BACKEND=sqlite SESH_KEY_SOURCE=password`:
  - First run prompts Create + Confirm, no retry on either.
  - Wrong → wrong → correct: succeeds on 3rd attempt, `(2/3)` and `(3/3)` retry markers appear.
  - Wrong × 3: fails with `wrong master password (after 3 attempts)`, no 4th prompt.
  - `SESH_MASTER_PASSWORD=wrong`: fails immediately with singular `wrong master password`, no prompt printed.
  - `SESH_MASTER_PASSWORD=correct`: succeeds silently in one shot.
  - Sidecar with version bumped to 99: `unsupported sidecar version 99 (expected 1)` immediately, no password prompt.
- [x] New unit tests (8 total): retry-then-succeed (asserts retry message + cache populates after retry), exhaust-attempts (asserts the count), default-single-attempt, prompt-error-breaks-loop, no-retry-on-sidecar-error (pins the timing-channel guarantee), `WithMaxAttempts` clamps below 1, `resolvePasswordPrompt` env-var branch, `resolvePasswordPrompt` non-TTY branch.

## Out of scope
- Piped-stdin master password input (`echo pw | sesh ...`). `term.ReadPassword` requires a TTY; piped input would need a separate non-echo reader. Pre-existing limitation, not a retry-feature concern.
- First-run create+confirm retry. Roadmap scopes retry to `unlock()` only; create+confirm intentionally fails fast on mismatch. Documented on `WithMaxAttempts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Master password retry: Users can now re-enter their password if incorrect, with up to 3 attempts available in interactive terminal sessions.

* **Bug Fixes**
  * Improved lock handling to prevent blocking concurrent operations during password prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->