### PR TITLE
Add in-place master password rotation via sesh --rekey --to password

### DIFF
--- a/docs/USAGE_AND_CONFIGURATION.md
+++ b/docs/USAGE_AND_CONFIGURATION.md
@@ -252,9 +252,39 @@ Behaviour:
 - **Recoverable.** On success, the original database is preserved at `<dbPath>.pre-rekey`. Verify the new state works, then remove the backup manually.
 - **Old key state is left in place.** Switching from keychain → password leaves the keychain entry; switching from password → keychain leaves the sidecar. Both become unused but are not auto-deleted (so you have an additional rollback path). The summary message points at how to clean them up.
 - **Refuses if the target is already initialised.** If a sidecar already exists for `--to password`, or a keychain entry already exists for `--to keychain`, rekey aborts and asks you to clean up manually before retrying.
-- **`--to <same as current>` is rejected.** Rotating within the same source (changing master password without switching) is not yet supported — use the encrypted-export route in the meantime.
+- **`--to password` while already in password mode is the rotation case.** See "Rotating your master password" below. The `keychain → keychain` analogue (rotating the random keychain key in place) is not yet supported.
 
 Timestamps (`created_at`, `updated_at`) are preserved across the rekey.
+
+### Rotating your master password
+
+When `SESH_KEY_SOURCE=password` is the active source, `sesh --rekey --to password` rotates the master password in place: every entry is re-encrypted under a freshly-derived key from a new password you choose, and the old sidecar is preserved as a backup.
+
+```bash
+SESH_BACKEND=sqlite SESH_KEY_SOURCE=password sesh --rekey --to password
+# Master password: ****                          # current password
+# About to rotate master password and re-encrypt 12 entries.
+#   source DB:           /Users/alice/Library/Application Support/sesh/passwords.db
+#   rollback DB after:   /Users/alice/Library/Application Support/sesh/passwords.db.pre-rotate
+#   rollback sidecar:    /Users/alice/Library/Application Support/sesh/passwords.key.pre-rotate
+#
+# Proceed? [y/N]: y
+# Create master password: ****                   # new password
+# Confirm master password: ****
+# Rotated 12 entries under a new master password.
+# Old DB preserved at /Users/alice/Library/Application Support/sesh/passwords.db.pre-rotate
+# Old sidecar preserved at /Users/alice/Library/Application Support/sesh/passwords.key.pre-rotate
+# Verify the new password works, then remove the .pre-rotate backups (use `shred -u` if available).
+```
+
+Behaviour:
+
+- **Atomic.** Either every entry is re-encrypted and both the DB + sidecar are swapped, or nothing changes. A copy failure cleans up the staging files and leaves the originals untouched.
+- **Recoverable on user error.** Both `passwords.db.pre-rotate` and `passwords.key.pre-rotate` are kept after success — if you discover later that you typo'd the new password during the confirm step, the old DB and sidecar are still there. Verify the new password works on real entries, then delete both `.pre-rotate` files (`shred -u` if your system has it).
+- **Refuses if any staging or backup file exists.** If a previous rotation crashed mid-flight or wasn't cleaned up, you'll be asked to remove the leftover `.new` / `.pre-rotate` files first. Clobbering them silently could destroy a recovery path.
+- **Same Argon2id parameters as the original sidecar.** Rotation generates a new salt and re-derives, but does not bump KDF cost parameters. If you want to upgrade those, that's a separate operation (currently via encrypted export → import with a fresh sidecar).
+
+
 
 ## Usage Patterns
 

--- a/internal/database/master_password.go
+++ b/internal/database/master_password.go
@@ -47,7 +47,12 @@ type MasterPasswordSource struct {
 	// would each fire ~64 MiB of Argon2id work in parallel.
 	sf         singleflight.Group
 	promptFunc PasswordPromptFunc
-	dataDir    string
+	// sidecarPath is the full path to the on-disk KDF state file. Stored
+	// directly (rather than being derived from a dataDir field) so that
+	// callers staging a rotation can point a target source at e.g.
+	// passwords.key.new while the source instance keeps reading from
+	// passwords.key. See NewMasterPasswordSourceAtPath.
+	sidecarPath string
 	// cachedKey holds the derived key after the first successful unlock.
 	// Scoped to the process lifetime only — cleared when Close() is called
 	// (or when the process exits). This avoids prompting the user on every
@@ -92,11 +97,22 @@ func WithMaxAttempts(n int) Option {
 	}
 }
 
-// NewMasterPasswordSource creates a MasterPasswordSource that stores its
-// sidecar in dataDir (typically the same directory as the SQLite DB).
+// NewMasterPasswordSource creates a MasterPasswordSource whose sidecar
+// lives at <dataDir>/passwords.key — the canonical layout used by the CLI.
+// Callers that need a non-canonical sidecar path (e.g., rotation staging)
+// should use NewMasterPasswordSourceAtPath directly.
 func NewMasterPasswordSource(dataDir string, prompt PasswordPromptFunc, opts ...Option) *MasterPasswordSource {
+	return NewMasterPasswordSourceAtPath(filepath.Join(dataDir, sidecarFileName), prompt, opts...)
+}
+
+// NewMasterPasswordSourceAtPath creates a MasterPasswordSource that reads
+// and writes its sidecar at the given absolute path. Useful when staging
+// a rotation: the source instance can point at passwords.key while a
+// target instance points at passwords.key.new, both running concurrently
+// without colliding.
+func NewMasterPasswordSourceAtPath(sidecarPath string, prompt PasswordPromptFunc, opts ...Option) *MasterPasswordSource {
 	s := &MasterPasswordSource{
-		dataDir:     dataDir,
+		sidecarPath: sidecarPath,
 		promptFunc:  prompt,
 		maxAttempts: 1,
 	}
@@ -117,10 +133,6 @@ func (s *MasterPasswordSource) Close() {
 		secure.SecureZeroBytes(s.cachedKey)
 		s.cachedKey = nil
 	}
-}
-
-func (s *MasterPasswordSource) sidecarPath() string {
-	return filepath.Join(s.dataDir, sidecarFileName)
 }
 
 // GetEncryptionKey prompts for the master password and derives the
@@ -189,7 +201,7 @@ func (s *MasterPasswordSource) GetEncryptionKey() ([]byte, error) {
 // process's derived key. Once the sidecar exists, unlock is salt-stable
 // and lock-free.
 func (s *MasterPasswordSource) acquireKey() ([]byte, error) {
-	path := s.sidecarPath()
+	path := s.sidecarPath
 	_, err := os.Stat(path)
 	switch {
 	case err == nil:
@@ -201,16 +213,16 @@ func (s *MasterPasswordSource) acquireKey() ([]byte, error) {
 }
 
 // initializeLocked serializes concurrent first-run invocations with an
-// advisory flock on <dataDir>/passwords.key.lock. The flock is auto-
-// released when the holding process exits, so crashes don't leave stale
-// locks. After acquiring the lock, the sidecar is re-checked — another
-// process may have created it while this one was blocked.
+// advisory flock on <sidecar>.lock. The flock is auto-released when the
+// holding process exits, so crashes don't leave stale locks. After
+// acquiring the lock, the sidecar is re-checked — another process may
+// have created it while this one was blocked.
 func (s *MasterPasswordSource) initializeLocked() ([]byte, error) {
-	if !filepath.IsAbs(s.dataDir) {
-		return nil, fmt.Errorf("data dir must be an absolute path, got %q", s.dataDir)
+	if !filepath.IsAbs(s.sidecarPath) {
+		return nil, fmt.Errorf("sidecar path must be absolute, got %q", s.sidecarPath)
 	}
-	sentinel := s.sidecarPath() + ".lock"
-	lockFile, err := os.OpenFile(sentinel, os.O_CREATE|os.O_RDWR, 0o600) //nolint:gosec // sentinel is <abs-dataDir>/passwords.key.lock; abs check above
+	sentinel := s.sidecarPath + ".lock"
+	lockFile, err := os.OpenFile(sentinel, os.O_CREATE|os.O_RDWR, 0o600) //nolint:gosec // sentinel is <abs-sidecar>.lock; abs check above
 	if err != nil {
 		return nil, fmt.Errorf("open sidecar lock: %w", err)
 	}
@@ -224,12 +236,31 @@ func (s *MasterPasswordSource) initializeLocked() ([]byte, error) {
 			fmt.Fprintf(os.Stderr, "warning: release sidecar lock: %v\n", cerr)
 		}
 	}
-	defer release()
+	defer func() {
+		release()
+		// Cleanup the sentinel only if the sidecar exists — meaning
+		// either we just wrote it via initialize(), or it existed when
+		// we re-stat'd. In both cases, no future invocation will enter
+		// initializeLocked again (acquireKey's stat at line 204 short-
+		// circuits to unlock when the sidecar is present), so the lock
+		// file is genuinely orphaned.
+		//
+		// Critically, we do NOT remove on error paths where the sidecar
+		// is still missing: a concurrent waiter blocked on our flock
+		// will acquire next and depend on the same lock file inode for
+		// serialization. Removing it would let a third arrival open a
+		// fresh inode and run initialize() in parallel.
+		if _, statErr := os.Stat(s.sidecarPath); statErr == nil {
+			if rerr := os.Remove(sentinel); rerr != nil && !os.IsNotExist(rerr) {
+				fmt.Fprintf(os.Stderr, "warning: remove sidecar lock: %v\n", rerr)
+			}
+		}
+	}()
 	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX); err != nil {
 		return nil, fmt.Errorf("acquire sidecar lock: %w", err)
 	}
 
-	switch _, err := os.Stat(s.sidecarPath()); {
+	switch _, err := os.Stat(s.sidecarPath); {
 	case err == nil:
 		// The flock's job was to serialize sidecar creation; with the
 		// sidecar already in place, drop it before falling into unlock()
@@ -385,7 +416,7 @@ func (s *MasterPasswordSource) writeSidecar(data sidecarData) error {
 	// Write to a temp file then rename so a crash mid-write leaves the
 	// old sidecar intact (or no sidecar at all on first run). Rename is
 	// atomic on POSIX and close-to-atomic on Windows.
-	path := s.sidecarPath()
+	path := s.sidecarPath
 	tmp := path + ".tmp"
 	if err := os.WriteFile(tmp, b, 0o600); err != nil {
 		return fmt.Errorf("write sidecar: %w", err)
@@ -400,7 +431,7 @@ func (s *MasterPasswordSource) writeSidecar(data sidecarData) error {
 }
 
 func (s *MasterPasswordSource) readSidecar() (sidecarData, error) {
-	path := s.sidecarPath()
+	path := s.sidecarPath
 	b, err := os.ReadFile(path) //nolint:gosec // path is <dataDir>/passwords.key; dataDir is caller-controlled via NewMasterPasswordSource
 	if err != nil {
 		return sidecarData{}, fmt.Errorf("read sidecar: %w", err)

--- a/internal/database/master_password_test.go
+++ b/internal/database/master_password_test.go
@@ -415,10 +415,10 @@ func TestMasterPasswordSource_RejectsShortVerify(t *testing.T) {
 	}
 }
 
-func TestMasterPasswordSource_RejectsNonAbsoluteDataDir(t *testing.T) {
+func TestMasterPasswordSource_RejectsNonAbsoluteSidecarPath(t *testing.T) {
 	src := NewMasterPasswordSource("relative/path", staticPrompt("password-12345", "password-12345"))
 	_, err := src.GetEncryptionKey()
-	if err == nil || !bytes.Contains([]byte(err.Error()), []byte("must be an absolute path")) {
+	if err == nil || !bytes.Contains([]byte(err.Error()), []byte("must be absolute")) {
 		t.Fatalf("expected absolute-path error, got %v", err)
 	}
 }
@@ -439,6 +439,75 @@ func TestMasterPasswordSource_SidecarHasNoSecrets(t *testing.T) {
 
 	if bytes.Contains(b, []byte(password)) {
 		t.Fatal("sidecar contains the master password in plaintext")
+	}
+}
+
+func TestInitializeLocked_RemovesLockFileAfterFirstInit(t *testing.T) {
+	// The .lock sentinel created by initializeLocked exists only to host
+	// an advisory flock during concurrent first-run. Once first-init has
+	// committed the sidecar, no future invocation will ever flock against
+	// this file again (acquireKey only enters initializeLocked when the
+	// sidecar doesn't exist, and the sidecar exists from now on). Leaving
+	// the .lock file on disk is harmless but noisy — clean it up.
+	dir := t.TempDir()
+	src := NewMasterPasswordSource(dir, staticPrompt("first-init-pw", "first-init-pw"))
+	defer src.Close()
+
+	key, err := src.GetEncryptionKey()
+	if err != nil {
+		t.Fatalf("first-init GetEncryptionKey: %v", err)
+	}
+	secure.SecureZeroBytes(key)
+
+	lockPath := filepath.Join(dir, sidecarFileName+".lock")
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Errorf("lock file %s should be removed after successful first-init, got stat err %v", lockPath, err)
+	}
+}
+
+func TestInitializeLocked_PreservesLockFileWhenInitFails(t *testing.T) {
+	// Safety property: when initialize() errors before writing the
+	// sidecar, the lock file MUST remain on disk so concurrent
+	// initializers stay serialized. Removing the lock file in error
+	// paths would let a new arrival open a fresh inode and run
+	// initialize() in parallel with an in-flight retry — racing on
+	// who writes the sidecar.
+	dir := t.TempDir()
+	src := NewMasterPasswordSource(dir, staticPrompt("create-pw-1234", "different-pw-5678"))
+	defer src.Close()
+
+	_, err := src.GetEncryptionKey()
+	if err == nil || !strings.Contains(err.Error(), "passwords do not match") {
+		t.Fatalf("expected passwords-do-not-match error, got %v", err)
+	}
+	lockPath := filepath.Join(dir, sidecarFileName+".lock")
+	if _, statErr := os.Stat(lockPath); statErr != nil {
+		t.Errorf("lock file %s should be preserved after init error (sidecar not yet written): %v", lockPath, statErr)
+	}
+	// And confirm the sidecar truly wasn't written, so the test setup
+	// matches its premise.
+	if _, statErr := os.Stat(filepath.Join(dir, sidecarFileName)); !os.IsNotExist(statErr) {
+		t.Errorf("sidecar should not exist after init error: %v", statErr)
+	}
+}
+
+func TestNewMasterPasswordSourceAtPath_HonorsCustomPath(t *testing.T) {
+	dir := t.TempDir()
+	customPath := filepath.Join(dir, "custom-name.key")
+	src := NewMasterPasswordSourceAtPath(customPath, staticPrompt("rotation-target", "rotation-target"))
+	defer src.Close()
+
+	key, err := src.GetEncryptionKey()
+	if err != nil {
+		t.Fatalf("GetEncryptionKey: %v", err)
+	}
+	secure.SecureZeroBytes(key)
+
+	if _, err := os.Stat(customPath); err != nil {
+		t.Errorf("sidecar should be at custom path %q: %v", customPath, err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, sidecarFileName)); !os.IsNotExist(err) {
+		t.Errorf("canonical sidecar path should not be touched when custom path is given")
 	}
 }
 

--- a/sesh/cmd/sesh/main.go
+++ b/sesh/cmd/sesh/main.go
@@ -230,11 +230,21 @@ func resolvePasswordPrompt() passwordPromptConfig {
 // newSource constructs a MasterPasswordSource using this config's prompt
 // and only enables the retry budget when the prompt is interactive.
 func (c passwordPromptConfig) newSource(dataDir string) *database.MasterPasswordSource {
-	var opts []database.Option
+	return database.NewMasterPasswordSource(dataDir, c.prompt, c.options()...)
+}
+
+// newSourceAtPath is the rotation-friendly variant: caller specifies the
+// sidecar path explicitly so a "target" source can stage at e.g.
+// passwords.key.new while the canonical source still reads passwords.key.
+func (c passwordPromptConfig) newSourceAtPath(sidecarPath string) *database.MasterPasswordSource {
+	return database.NewMasterPasswordSourceAtPath(sidecarPath, c.prompt, c.options()...)
+}
+
+func (c passwordPromptConfig) options() []database.Option {
 	if c.interactive {
-		opts = append(opts, database.WithMaxAttempts(interactivePasswordAttempts))
+		return []database.Option{database.WithMaxAttempts(interactivePasswordAttempts)}
 	}
-	return database.NewMasterPasswordSource(dataDir, c.prompt, opts...)
+	return nil
 }
 
 // terminalPrompt reads a password from the controlling terminal without

--- a/sesh/cmd/sesh/rekey.go
+++ b/sesh/cmd/sesh/rekey.go
@@ -18,10 +18,11 @@ import (
 )
 
 const (
-	rekeyDestSuffix   = ".new"
-	rekeyBackupSuffix = ".pre-rekey"
-	encKeyService     = "sesh-sqlite-encryption-key"
-	sidecarFile       = "passwords.key"
+	rekeyDestSuffix    = ".new"
+	rekeyBackupSuffix  = ".pre-rekey"
+	rotateBackupSuffix = ".pre-rotate"
+	encKeyService      = "sesh-sqlite-encryption-key"
+	sidecarFile        = "passwords.key"
 )
 
 // runRekey re-encrypts the SQLite store under a different KeySource and
@@ -52,6 +53,13 @@ func runRekey(app *App, args []string, kc keychain.Provider) (err error) {
 
 	current := currentKeySourceName()
 	if current == *target {
+		// password → password is the in-place rotation case ("change my
+		// master password"). Other same-source pairs (e.g. keychain →
+		// keychain) aren't supported in this branch yet; see Flavor B
+		// in docs/KEY_ROTATION_ROADMAP.md.
+		if current == "password" {
+			return runRotateMasterPassword(app, resolvePasswordPrompt())
+		}
 		return fmt.Errorf("already using %s; nothing to do", *target)
 	}
 
@@ -369,6 +377,248 @@ func unusedKeyStateNote(oldSource, dataDir string) string {
 	default:
 		return ""
 	}
+}
+
+// runRotateMasterPassword re-encrypts every entry under a freshly-derived
+// key from a new master password. The old sidecar is preserved at
+// passwords.key.pre-rotate and the old DB at <dbPath>.pre-rotate so the
+// user has a recovery path if they later realize they typed the new
+// password wrong (e.g. caps lock during the confirm step).
+//
+// Distinct from runRekey's source-switching path: source and target both
+// use MasterPasswordSource; the only thing that changes is the salt and
+// the derived key. The target source is constructed against a staging
+// sidecar path (.new) so the canonical path keeps unlocking with the old
+// password until the very end.
+//
+// cfg is the prompt configuration shared by source and target sources.
+// Production passes resolvePasswordPrompt(); tests inject a sequenced
+// prompt that returns the old password first, then the new one twice.
+func runRotateMasterPassword(app *App, cfg passwordPromptConfig) (err error) {
+	if os.Getenv("SESH_BACKEND") != "sqlite" {
+		return fmt.Errorf("rotate requires SESH_BACKEND=sqlite")
+	}
+
+	dbPath, err := database.DefaultDBPath()
+	if err != nil {
+		return fmt.Errorf("resolve database path: %w", err)
+	}
+	dataDir := filepath.Dir(dbPath)
+	sidecarPath := filepath.Join(dataDir, sidecarFile)
+
+	dbNewPath := dbPath + rekeyDestSuffix
+	dbBackupPath := dbPath + rotateBackupSuffix
+	sidecarNewPath := sidecarPath + rekeyDestSuffix
+	sidecarBackupPath := sidecarPath + rotateBackupSuffix
+
+	if _, err := os.Stat(dbPath); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("no database to rotate at %s", dbPath)
+		}
+		return fmt.Errorf("stat database: %w", err)
+	}
+	if _, err := os.Stat(sidecarPath); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("no sidecar to rotate at %s — is SESH_KEY_SOURCE=password actually in use?", sidecarPath)
+		}
+		return fmt.Errorf("stat sidecar: %w", err)
+	}
+	// Refuse if any staging or backup file from a prior attempt is still
+	// around. Clobbering a prior backup would silently destroy a recovery
+	// path; clobbering a prior staging file might silently mix old and
+	// new state.
+	for _, p := range []string{dbNewPath, dbBackupPath, sidecarNewPath, sidecarBackupPath} {
+		if _, err := os.Stat(p); err == nil {
+			return fmt.Errorf("path %s exists from a prior rotation; remove it (or rename to preserve a prior backup) and retry", p)
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("stat %s: %w", p, err)
+		}
+	}
+
+	srcKS := cfg.newSource(dataDir)
+	srcStore, err := database.Open(dbPath, srcKS)
+	if err != nil {
+		return fmt.Errorf("open source database: %w", err)
+	}
+
+	// Rollback state — same shape as runRekey. Anything *true / non-empty
+	// when err != nil gets unwound; commit zeros them so cleanup no-ops.
+	var (
+		destStore      *database.Store
+		destStoreOpen  bool
+		destDBCreated  bool
+		newSidecarMade bool
+		srcStoreOpen   = true
+		dbRenamed      bool
+		sidecarRenamed bool
+	)
+
+	defer func() {
+		if srcStoreOpen {
+			if cerr := srcStore.Close(); cerr != nil {
+				err = appendErr(err, "close source store", cerr)
+			}
+		}
+		if err == nil {
+			return
+		}
+		if destStoreOpen && destStore != nil {
+			if cerr := destStore.Close(); cerr != nil {
+				err = appendErr(err, "rollback close destination store", cerr)
+			}
+		}
+		if destDBCreated {
+			if rerr := os.Remove(dbNewPath); rerr != nil && !os.IsNotExist(rerr) {
+				err = appendErr(err, "rollback remove staged DB", rerr)
+			}
+		}
+		if newSidecarMade {
+			if rerr := os.Remove(sidecarNewPath); rerr != nil && !os.IsNotExist(rerr) {
+				err = appendErr(err, "rollback remove staged sidecar", rerr)
+			}
+		}
+		// The lock-file sentinel (sidecarNewPath + ".lock") gets created
+		// by initializeLocked the moment we open it with O_CREATE — that
+		// happens before any password prompt, so it can be on disk even
+		// when newSidecarMade is false (e.g. mismatched-confirm errors
+		// thrown from initialize). Remove it unconditionally; IsNotExist
+		// handles the never-created case.
+		if rerr := os.Remove(sidecarNewPath + ".lock"); rerr != nil && !os.IsNotExist(rerr) {
+			err = appendErr(err, "rollback remove staged sidecar lock", rerr)
+		}
+		// If only the DB rename succeeded, restore it. The sidecar is
+		// still canonical at this point (rename happens after DB).
+		if dbRenamed && !sidecarRenamed {
+			if rerr := os.Rename(dbBackupPath, dbPath); rerr != nil {
+				err = appendErr(err, fmt.Sprintf("restore original DB to %s", dbPath), rerr)
+			}
+		}
+	}()
+
+	// Surface "wrong current password" before we ask for the new one. The
+	// retry loop in unlock() gives the user up to 3 tries on an interactive
+	// TTY — driven by cfg.interactive.
+	srcKey, err := srcKS.GetEncryptionKey()
+	if err != nil {
+		return fmt.Errorf("unlock current sidecar: %w", err)
+	}
+	secure.SecureZeroBytes(srcKey)
+
+	plan, err := migration.Plan(srcStore)
+	if err != nil {
+		return fmt.Errorf("scan source: %w", err)
+	}
+
+	if _, perr := fmt.Fprintf(app.Stderr, "About to rotate master password and re-encrypt %d entries.\n", len(plan)); perr != nil {
+		return perr
+	}
+	if _, perr := fmt.Fprintf(app.Stderr, "  source DB:           %s\n", dbPath); perr != nil {
+		return perr
+	}
+	if _, perr := fmt.Fprintf(app.Stderr, "  rollback DB after:   %s\n", dbBackupPath); perr != nil {
+		return perr
+	}
+	if _, perr := fmt.Fprintf(app.Stderr, "  rollback sidecar:    %s\n", sidecarBackupPath); perr != nil {
+		return perr
+	}
+	confirmed, err := promptYesNo(app.Stdin, app.Stderr, "\nProceed? [y/N]: ")
+	if err != nil {
+		return err
+	}
+	if !confirmed {
+		if _, perr := fmt.Fprintln(app.Stderr, "Rotation cancelled."); perr != nil {
+			return perr
+		}
+		return nil
+	}
+
+	// Build the target source against the staged sidecar path. The first
+	// GetEncryptionKey on this source triggers initialize() — i.e. the
+	// "Create master password" + "Confirm master password" prompts that
+	// generate the new salt and write the .new sidecar.
+	destKS := cfg.newSourceAtPath(sidecarNewPath)
+	destKey, err := destKS.GetEncryptionKey()
+	if err != nil {
+		return fmt.Errorf("create new sidecar: %w", err)
+	}
+	secure.SecureZeroBytes(destKey)
+	newSidecarMade = true
+
+	destStore, err = database.Open(dbNewPath, destKS)
+	if err != nil {
+		return fmt.Errorf("open destination database: %w", err)
+	}
+	destStoreOpen = true
+	destDBCreated = true
+	if err := destStore.InitKeyMetadata(); err != nil {
+		return fmt.Errorf("init target key metadata: %w", err)
+	}
+
+	result, err := migration.Migrate(srcStore, destStore)
+	if err != nil {
+		return fmt.Errorf("copy entries: %w", err)
+	}
+	if len(result.Errors) > 0 {
+		return fmt.Errorf("copy reported %d errors:\n  %s", len(result.Errors), strings.Join(result.Errors, "\n  "))
+	}
+
+	// Close stores before rename so SQLite checkpoints WAL and removes
+	// the -wal/-shm sidecars; otherwise the rename leaves orphans.
+	if err := destStore.Close(); err != nil {
+		return fmt.Errorf("close destination store: %w", err)
+	}
+	destStore = nil
+	destStoreOpen = false
+	if err := srcStore.Close(); err != nil {
+		return fmt.Errorf("close source store: %w", err)
+	}
+	srcStoreOpen = false
+
+	// Atomic swap. Order matters: rename DB first; if sidecar rename then
+	// fails, the new DB sees the OLD sidecar — which can't decrypt it.
+	// The rollback restores the DB rename. If the sidecar rename also
+	// fails after we've already swapped DB+sidecar, we're committed —
+	// surface both paths so the user can finish manually.
+	if err := os.Rename(dbPath, dbBackupPath); err != nil {
+		return fmt.Errorf("rename source DB to backup: %w", err)
+	}
+	dbRenamed = true
+	if err := os.Rename(dbNewPath, dbPath); err != nil {
+		return fmt.Errorf("rename destination DB into place: %w", err)
+	}
+	destDBCreated = false // canonical now; rollback no longer applies
+
+	if err := os.Rename(sidecarPath, sidecarBackupPath); err != nil {
+		return fmt.Errorf("rename source sidecar to backup: %w (DB is now at %s; restore manually if needed)", err, dbPath)
+	}
+	if err := os.Rename(sidecarNewPath, sidecarPath); err != nil {
+		return fmt.Errorf("rename destination sidecar into place: %w (DB is at %s, old sidecar at %s, new sidecar at %s — finish the rename manually)", err, dbPath, sidecarBackupPath, sidecarNewPath)
+	}
+	sidecarRenamed = true
+	newSidecarMade = false
+
+	// The .new.lock sentinel was created when destKS first ran
+	// initializeLocked. The .new sidecar it guarded has now been renamed
+	// to the canonical path, so the lock file is genuinely orphaned —
+	// nothing will ever flock against it again. Best-effort cleanup;
+	// don't fail the rotation if remove fails.
+	if rerr := os.Remove(sidecarNewPath + ".lock"); rerr != nil && !os.IsNotExist(rerr) {
+		fmt.Fprintf(app.Stderr, "warning: remove staged sidecar lock %s: %v\n", sidecarNewPath+".lock", rerr) //nolint:errcheck // best-effort cleanup warning; failing to print it shouldn't fail the rotation
+	}
+
+	if _, perr := fmt.Fprintf(app.Stderr, "\nRotated %d entries under a new master password.\n", result.Migrated); perr != nil {
+		return perr
+	}
+	if _, perr := fmt.Fprintf(app.Stderr, "Old DB preserved at %s\n", dbBackupPath); perr != nil {
+		return perr
+	}
+	if _, perr := fmt.Fprintf(app.Stderr, "Old sidecar preserved at %s\n", sidecarBackupPath); perr != nil {
+		return perr
+	}
+	if _, perr := fmt.Fprintln(app.Stderr, "Verify the new password works, then remove the .pre-rotate backups (use `shred -u` if available)."); perr != nil {
+		return perr
+	}
+	return nil
 }
 
 // promptYesNo reads a y/N answer from stdin. Empty input (bare Enter) is "No"

--- a/sesh/cmd/sesh/rekey_test.go
+++ b/sesh/cmd/sesh/rekey_test.go
@@ -892,6 +892,104 @@ func TestRotate_RemovesStagingLockOnCancel(t *testing.T) {
 	}
 }
 
+func TestRotate_RefusesIfBackendNotSqlite(t *testing.T) {
+	t.Setenv("SESH_BACKEND", "")
+	app, _ := rekeyTestApp("")
+	err := runRotateMasterPassword(app, rotateTestCfg("any-pw-1234"))
+	if err == nil || !strings.Contains(err.Error(), "SESH_BACKEND=sqlite") {
+		t.Fatalf("expected SESH_BACKEND error, got %v", err)
+	}
+}
+
+func TestRotate_RefusesIfDatabaseMissing(t *testing.T) {
+	setupRekeyEnv(t)
+	t.Setenv("SESH_KEY_SOURCE", "password")
+	app, _ := rekeyTestApp("")
+	err := runRotateMasterPassword(app, rotateTestCfg("any-pw-1234"))
+	if err == nil || !strings.Contains(err.Error(), "no database to rotate") {
+		t.Fatalf("expected no-database error, got %v", err)
+	}
+}
+
+func TestRotate_RefusesIfSidecarMissing(t *testing.T) {
+	env := setupRekeyEnv(t)
+	t.Setenv("SESH_KEY_SOURCE", "password")
+	// Create a DB file directly (bypassing sesh) so the DB-stat check passes
+	// but the sidecar doesn't exist — the "is SESH_KEY_SOURCE=password
+	// actually in use?" failure mode.
+	if err := os.MkdirAll(env.dataDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(env.dbPath, []byte("not a real db"), 0o600); err != nil {
+		t.Fatalf("write fake db: %v", err)
+	}
+	app, _ := rekeyTestApp("")
+	err := runRotateMasterPassword(app, rotateTestCfg("any-pw-1234"))
+	if err == nil || !strings.Contains(err.Error(), "no sidecar to rotate") {
+		t.Fatalf("expected no-sidecar error, got %v", err)
+	}
+}
+
+func TestRotate_PasswordRefusesIfNewDBExists(t *testing.T) {
+	env := setupRekeyEnv(t)
+	t.Setenv("SESH_KEY_SOURCE", "password")
+	t.Setenv("SESH_MASTER_PASSWORD", "old-pw-1234")
+	populatePasswordStore(t, env, map[string]string{"sesh-password/password/x/y": "v"})
+
+	if err := os.WriteFile(env.dbPath+rekeyDestSuffix, []byte("stale"), 0o600); err != nil {
+		t.Fatalf("pre-create staging DB: %v", err)
+	}
+
+	t.Setenv("SESH_MASTER_PASSWORD", "")
+	app, _ := rekeyTestApp("y\n")
+	cfg := rotateTestCfg("old-pw-1234", "new-pw-5678", "new-pw-5678")
+	err := runRotateMasterPassword(app, cfg)
+	if err == nil || !strings.Contains(err.Error(), "exists from a prior rotation") {
+		t.Fatalf("expected refusal because staging DB exists, got %v", err)
+	}
+}
+
+func TestRotate_PasswordRefusesIfBackupDBExists(t *testing.T) {
+	env := setupRekeyEnv(t)
+	t.Setenv("SESH_KEY_SOURCE", "password")
+	t.Setenv("SESH_MASTER_PASSWORD", "old-pw-1234")
+	populatePasswordStore(t, env, map[string]string{"sesh-password/password/x/y": "v"})
+
+	if err := os.WriteFile(env.dbPath+rotateBackupSuffix, []byte("stale"), 0o600); err != nil {
+		t.Fatalf("pre-create backup DB: %v", err)
+	}
+
+	t.Setenv("SESH_MASTER_PASSWORD", "")
+	app, _ := rekeyTestApp("y\n")
+	cfg := rotateTestCfg("old-pw-1234", "new-pw-5678", "new-pw-5678")
+	err := runRotateMasterPassword(app, cfg)
+	if err == nil || !strings.Contains(err.Error(), "exists from a prior rotation") {
+		t.Fatalf("expected refusal because backup DB exists, got %v", err)
+	}
+}
+
+func TestRotate_WrongSourcePassword(t *testing.T) {
+	env := setupRekeyEnv(t)
+	t.Setenv("SESH_KEY_SOURCE", "password")
+	t.Setenv("SESH_MASTER_PASSWORD", "right-pw-1234")
+	populatePasswordStore(t, env, map[string]string{"sesh-password/password/x/y": "v"})
+
+	t.Setenv("SESH_MASTER_PASSWORD", "")
+	app, _ := rekeyTestApp("y\n")
+	// Wrong source password — fails at unlock before any prompt for a new
+	// password. cfg only provides the wrong one; if we accidentally drained
+	// further from the sequence, the "test prompt exhausted" error would
+	// surface and tell us the test no longer pins the right behavior.
+	cfg := rotateTestCfg("wrong-pw-1234")
+	err := runRotateMasterPassword(app, cfg)
+	if err == nil || !strings.Contains(err.Error(), "unlock current sidecar") {
+		t.Fatalf("expected unlock error for wrong source password, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "wrong master password") {
+		t.Errorf("error %q should bubble up the underlying wrong-password message", err.Error())
+	}
+}
+
 func TestRotate_PasswordCancelledLeavesNoChanges(t *testing.T) {
 	env := setupRekeyEnv(t)
 	t.Setenv("SESH_KEY_SOURCE", "password")

--- a/sesh/cmd/sesh/rekey_test.go
+++ b/sesh/cmd/sesh/rekey_test.go
@@ -237,18 +237,22 @@ func TestRekey_RefusesIfTargetInvalid(t *testing.T) {
 	}
 }
 
-func TestRekey_RefusesIfSameSource(t *testing.T) {
+func TestRekey_RefusesKeychainToKeychain(t *testing.T) {
+	// password → password is the in-place rotation case and is handled
+	// by runRotateMasterPassword; see TestRotate_*. The keychain → keychain
+	// case isn't supported yet (Flavor B in docs/KEY_ROTATION_ROADMAP.md)
+	// and should still hit the "already using" guard.
 	env := setupRekeyEnv(t)
-	t.Setenv("SESH_KEY_SOURCE", "password")
-	t.Setenv("SESH_MASTER_PASSWORD", "test-password-1234")
-	populatePasswordStore(t, env, map[string]string{
+	t.Setenv("SESH_KEY_SOURCE", "keychain")
+	kc := newKCMock(hexKey())
+	populateKeychainStore(t, env, kc, map[string]string{
 		"sesh-password/password/github/alice": "hunter2",
 	})
 
 	app, _ := rekeyTestApp("")
-	err := runRekey(app, []string{"--to=password"}, nil)
+	err := runRekey(app, []string{"--to=keychain"}, kc)
 	if err == nil || !strings.Contains(err.Error(), "already using") {
-		t.Fatalf("expected already-using error, got %v", err)
+		t.Fatalf("expected already-using error for keychain→keychain, got %v", err)
 	}
 }
 
@@ -681,6 +685,249 @@ func TestPromptYesNo(t *testing.T) {
 				t.Errorf("promptYesNo(%q) = %v, want %v", input, got, want)
 			}
 		})
+	}
+}
+
+// sequencedPrompt returns each password in order, erroring once the list
+// is exhausted. Used by rotation tests where source unlock and target
+// create+confirm need different inputs from the same prompt callback.
+func sequencedPrompt(passwords ...string) database.PasswordPromptFunc {
+	i := 0
+	return func(_ string) ([]byte, error) {
+		if i >= len(passwords) {
+			return nil, fmt.Errorf("test prompt exhausted at call %d", i+1)
+		}
+		pw := []byte(passwords[i])
+		i++
+		return pw, nil
+	}
+}
+
+// rotateTestCfg builds a non-interactive prompt config from a sequenced
+// list of passwords. Non-interactive disables the retry loop, which is
+// what we want in tests — a wrong password should fail fast, not consume
+// extra entries from the sequence.
+func rotateTestCfg(passwords ...string) passwordPromptConfig {
+	return passwordPromptConfig{prompt: sequencedPrompt(passwords...), interactive: false}
+}
+
+func TestRotate_PasswordChangesPassword(t *testing.T) {
+	env := setupRekeyEnv(t)
+	t.Setenv("SESH_KEY_SOURCE", "password")
+	t.Setenv("SESH_MASTER_PASSWORD", "old-pw-1234")
+	entries := map[string]string{
+		"sesh-password/password/github/alice": "hunter2",
+		"sesh-password/api_key/stripe/admin":  "sk_test_xyz",
+	}
+	populatePasswordStore(t, env, entries)
+	t.Setenv("SESH_MASTER_PASSWORD", "")
+
+	app, stderr := rekeyTestApp("y\n")
+	cfg := rotateTestCfg("old-pw-1234", "new-pw-5678", "new-pw-5678")
+	if err := runRotateMasterPassword(app, cfg); err != nil {
+		t.Fatalf("runRotateMasterPassword: %v\nstderr:\n%s", err, stderr.String())
+	}
+
+	if !strings.Contains(stderr.String(), "Rotated 2 entries") {
+		t.Errorf("stderr missing rotation summary:\n%s", stderr.String())
+	}
+	if _, err := os.Stat(env.dbPath + rotateBackupSuffix); err != nil {
+		t.Errorf("DB backup missing at .pre-rotate: %v", err)
+	}
+	if _, err := os.Stat(env.sidecarPath + rotateBackupSuffix); err != nil {
+		t.Errorf("sidecar backup missing at .pre-rotate: %v", err)
+	}
+
+	// New password unlocks the rotated DB.
+	t.Setenv("SESH_MASTER_PASSWORD", "new-pw-5678")
+	services := []string{"sesh-password/password/github/alice", "sesh-password/api_key/stripe/admin"}
+	got := readEntriesViaPassword(t, env, services)
+	for svc, want := range entries {
+		if got[svc] != want {
+			t.Errorf("entry %s under new password = %q, want %q", svc, got[svc], want)
+		}
+	}
+}
+
+func TestRotate_PreservesPerEntryFreshness(t *testing.T) {
+	env := setupRekeyEnv(t)
+	t.Setenv("SESH_KEY_SOURCE", "password")
+	t.Setenv("SESH_MASTER_PASSWORD", "old-pw-1234")
+	populatePasswordStore(t, env, map[string]string{
+		"sesh-password/password/github/alice": "same-secret",
+		"sesh-password/password/github/bob":   "same-secret",
+	})
+
+	beforeBlob, err := os.ReadFile(env.dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("SESH_MASTER_PASSWORD", "")
+	app, _ := rekeyTestApp("y\n")
+	cfg := rotateTestCfg("old-pw-1234", "new-pw-5678", "new-pw-5678")
+	if err := runRotateMasterPassword(app, cfg); err != nil {
+		t.Fatalf("rotate: %v", err)
+	}
+
+	afterBlob, err := os.ReadFile(env.dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Equal(beforeBlob, afterBlob) {
+		t.Fatal("rotated DB byte-for-byte identical to original — re-encryption did not run")
+	}
+
+	// Sidecar salt must also have changed (proves new KDF derivation, not
+	// just a re-encryption with the same derived key).
+	beforeSidecar, err := os.ReadFile(env.sidecarPath + rotateBackupSuffix)
+	if err != nil {
+		t.Fatalf("read backup sidecar: %v", err)
+	}
+	afterSidecar, err := os.ReadFile(env.sidecarPath)
+	if err != nil {
+		t.Fatalf("read rotated sidecar: %v", err)
+	}
+	if bytes.Equal(beforeSidecar, afterSidecar) {
+		t.Fatal("rotated sidecar identical to backup — salt was not regenerated")
+	}
+}
+
+func TestRotate_PasswordRefusesIfNewSidecarExists(t *testing.T) {
+	env := setupRekeyEnv(t)
+	t.Setenv("SESH_KEY_SOURCE", "password")
+	t.Setenv("SESH_MASTER_PASSWORD", "old-pw-1234")
+	populatePasswordStore(t, env, map[string]string{"sesh-password/password/x/y": "v"})
+
+	if err := os.WriteFile(env.sidecarPath+rekeyDestSuffix, []byte("stale"), 0o600); err != nil {
+		t.Fatalf("pre-create staging sidecar: %v", err)
+	}
+
+	t.Setenv("SESH_MASTER_PASSWORD", "")
+	app, _ := rekeyTestApp("y\n")
+	cfg := rotateTestCfg("old-pw-1234", "new-pw-5678", "new-pw-5678")
+	err := runRotateMasterPassword(app, cfg)
+	if err == nil || !strings.Contains(err.Error(), "exists from a prior rotation") {
+		t.Fatalf("expected refusal because staging sidecar exists, got %v", err)
+	}
+}
+
+func TestRotate_PasswordRefusesIfBackupSidecarExists(t *testing.T) {
+	env := setupRekeyEnv(t)
+	t.Setenv("SESH_KEY_SOURCE", "password")
+	t.Setenv("SESH_MASTER_PASSWORD", "old-pw-1234")
+	populatePasswordStore(t, env, map[string]string{"sesh-password/password/x/y": "v"})
+
+	if err := os.WriteFile(env.sidecarPath+rotateBackupSuffix, []byte("stale"), 0o600); err != nil {
+		t.Fatalf("pre-create backup sidecar: %v", err)
+	}
+
+	t.Setenv("SESH_MASTER_PASSWORD", "")
+	app, _ := rekeyTestApp("y\n")
+	cfg := rotateTestCfg("old-pw-1234", "new-pw-5678", "new-pw-5678")
+	err := runRotateMasterPassword(app, cfg)
+	if err == nil || !strings.Contains(err.Error(), "exists from a prior rotation") {
+		t.Fatalf("expected refusal because backup sidecar exists, got %v", err)
+	}
+}
+
+func TestRotate_RemovesStagingLockOnSuccess(t *testing.T) {
+	env := setupRekeyEnv(t)
+	t.Setenv("SESH_KEY_SOURCE", "password")
+	t.Setenv("SESH_MASTER_PASSWORD", "old-pw-1234")
+	populatePasswordStore(t, env, map[string]string{"sesh-password/password/x/y": "v"})
+
+	t.Setenv("SESH_MASTER_PASSWORD", "")
+	app, _ := rekeyTestApp("y\n")
+	cfg := rotateTestCfg("old-pw-1234", "new-pw-5678", "new-pw-5678")
+	if err := runRotateMasterPassword(app, cfg); err != nil {
+		t.Fatalf("rotate: %v", err)
+	}
+	stagingLock := env.sidecarPath + rekeyDestSuffix + ".lock"
+	if _, err := os.Stat(stagingLock); !os.IsNotExist(err) {
+		t.Errorf("staging sidecar lock %s should be removed after successful rotation, got stat err %v", stagingLock, err)
+	}
+}
+
+func TestRotate_RemovesStagingLockOnConfirmMismatch(t *testing.T) {
+	env := setupRekeyEnv(t)
+	t.Setenv("SESH_KEY_SOURCE", "password")
+	t.Setenv("SESH_MASTER_PASSWORD", "old-pw-1234")
+	populatePasswordStore(t, env, map[string]string{"sesh-password/password/x/y": "v"})
+
+	t.Setenv("SESH_MASTER_PASSWORD", "")
+	app, _ := rekeyTestApp("y\n")
+	// Mismatched confirm fires inside initialize(), AFTER the staging
+	// lock file has been created via O_CREATE in initializeLocked. The
+	// lock file should be cleaned up by the rollback path.
+	cfg := rotateTestCfg("old-pw-1234", "new-pw-aaaaaa", "new-pw-bbbbbb")
+	err := runRotateMasterPassword(app, cfg)
+	if err == nil || !strings.Contains(err.Error(), "passwords do not match") {
+		t.Fatalf("expected passwords-do-not-match error, got %v", err)
+	}
+	stagingLock := env.sidecarPath + rekeyDestSuffix + ".lock"
+	if _, err := os.Stat(stagingLock); !os.IsNotExist(err) {
+		t.Errorf("staging sidecar lock %s should be removed after rollback, got stat err %v", stagingLock, err)
+	}
+}
+
+func TestRotate_RemovesStagingLockOnCancel(t *testing.T) {
+	env := setupRekeyEnv(t)
+	t.Setenv("SESH_KEY_SOURCE", "password")
+	t.Setenv("SESH_MASTER_PASSWORD", "old-pw-1234")
+	populatePasswordStore(t, env, map[string]string{"sesh-password/password/x/y": "v"})
+
+	t.Setenv("SESH_MASTER_PASSWORD", "")
+	// Cancel before the destination source is constructed at all — the
+	// staging lock should never be created. Regression guard against a
+	// future change that moves destKS construction earlier.
+	app, _ := rekeyTestApp("n\n")
+	cfg := rotateTestCfg("old-pw-1234")
+	if err := runRotateMasterPassword(app, cfg); err != nil {
+		t.Fatalf("cancelled rotation should not error: %v", err)
+	}
+	stagingLock := env.sidecarPath + rekeyDestSuffix + ".lock"
+	if _, err := os.Stat(stagingLock); !os.IsNotExist(err) {
+		t.Errorf("staging sidecar lock %s should not exist after cancel, got stat err %v", stagingLock, err)
+	}
+}
+
+func TestRotate_PasswordCancelledLeavesNoChanges(t *testing.T) {
+	env := setupRekeyEnv(t)
+	t.Setenv("SESH_KEY_SOURCE", "password")
+	t.Setenv("SESH_MASTER_PASSWORD", "old-pw-1234")
+	populatePasswordStore(t, env, map[string]string{"sesh-password/password/x/y": "v"})
+	beforeBlob, err := os.ReadFile(env.dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("SESH_MASTER_PASSWORD", "")
+	// Pass "n" to the y/N prompt to abort. Source unlock still happens (one
+	// password drained from the sequence); target Create+Confirm is never
+	// reached, so only the source password is consumed.
+	app, _ := rekeyTestApp("n\n")
+	cfg := rotateTestCfg("old-pw-1234")
+	if err := runRotateMasterPassword(app, cfg); err != nil {
+		t.Fatalf("cancelled rotation should not error: %v", err)
+	}
+
+	afterBlob, err := os.ReadFile(env.dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(beforeBlob, afterBlob) {
+		t.Error("DB modified after cancelled rotation")
+	}
+	for _, p := range []string{
+		env.dbPath + rekeyDestSuffix,
+		env.dbPath + rotateBackupSuffix,
+		env.sidecarPath + rekeyDestSuffix,
+		env.sidecarPath + rotateBackupSuffix,
+	} {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Errorf("staging/backup file %s should not exist after cancel: %v", p, err)
+		}
 	}
 }
 

--- a/sesh/cmd/sesh/rekey_test.go
+++ b/sesh/cmd/sesh/rekey_test.go
@@ -973,6 +973,10 @@ func TestRotate_WrongSourcePassword(t *testing.T) {
 	t.Setenv("SESH_KEY_SOURCE", "password")
 	t.Setenv("SESH_MASTER_PASSWORD", "right-pw-1234")
 	populatePasswordStore(t, env, map[string]string{"sesh-password/password/x/y": "v"})
+	beforeSidecar, err := os.ReadFile(env.sidecarPath)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	t.Setenv("SESH_MASTER_PASSWORD", "")
 	app, _ := rekeyTestApp("y\n")
@@ -981,12 +985,22 @@ func TestRotate_WrongSourcePassword(t *testing.T) {
 	// further from the sequence, the "test prompt exhausted" error would
 	// surface and tell us the test no longer pins the right behavior.
 	cfg := rotateTestCfg("wrong-pw-1234")
-	err := runRotateMasterPassword(app, cfg)
+	err = runRotateMasterPassword(app, cfg)
 	if err == nil || !strings.Contains(err.Error(), "unlock current sidecar") {
 		t.Fatalf("expected unlock error for wrong source password, got %v", err)
 	}
 	if !strings.Contains(err.Error(), "wrong master password") {
 		t.Errorf("error %q should bubble up the underlying wrong-password message", err.Error())
+	}
+	// Canonical sidecar must be untouched. No write path is reachable
+	// before the failed unlock, so this is a regression guard against
+	// future refactors that move sidecar writes earlier in the flow.
+	afterSidecar, err := os.ReadFile(env.sidecarPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(beforeSidecar, afterSidecar) {
+		t.Error("canonical sidecar modified after wrong-password failure")
 	}
 }
 
@@ -996,6 +1010,10 @@ func TestRotate_PasswordCancelledLeavesNoChanges(t *testing.T) {
 	t.Setenv("SESH_MASTER_PASSWORD", "old-pw-1234")
 	populatePasswordStore(t, env, map[string]string{"sesh-password/password/x/y": "v"})
 	beforeBlob, err := os.ReadFile(env.dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeSidecar, err := os.ReadFile(env.sidecarPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1016,6 +1034,13 @@ func TestRotate_PasswordCancelledLeavesNoChanges(t *testing.T) {
 	}
 	if !bytes.Equal(beforeBlob, afterBlob) {
 		t.Error("DB modified after cancelled rotation")
+	}
+	afterSidecar, err := os.ReadFile(env.sidecarPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(beforeSidecar, afterSidecar) {
+		t.Error("canonical sidecar modified after cancelled rotation")
 	}
 	for _, p := range []string{
 		env.dbPath + rekeyDestSuffix,


### PR DESCRIPTION
## Summary
- Implements Flavor A from `docs/KEY_ROTATION_ROADMAP.md` ("change my master password"). When `SESH_KEY_SOURCE=password` is the active source, `sesh --rekey --to password` re-encrypts every entry under a freshly-derived key from a new password the user picks. Old DB and sidecar are preserved as `.pre-rotate` backups.
- Prerequisite for the agent work: `docs/SESH_AGENT_ROADMAP.md` line 25 names this feature explicitly. With it landed, the agent can be designed knowing rotation invalidates cached keys cleanly.
- Drive-by lock-file cleanup. The first-init flock sentinel (`passwords.key.lock`) and the rotation-staging flock sentinel (`passwords.key.new.lock`) used to linger on disk forever. Both are now cleaned up under provably-safe invariants.

## Acceptance criteria (from roadmap, section "Flavor A")
- [x] Sidecar path is configurable on `MasterPasswordSource` so source and target can stage at different paths simultaneously.
- [x] `runRekey` treats `password → password` as in-place rotation; `keychain → keychain` still errors (Flavor B not in scope).
- [x] Pre-flight refuses if any of `<sidecar>.new`, `<sidecar>.pre-rotate`, `<dbPath>.new`, or `<dbPath>.pre-rotate` exist (no silent clobbering of prior backups or staging).
- [x] Atomic swap: rename DB first, then sidecar. On partial failure, error message names every path the user needs to recover.
- [x] Rollback on any pre-commit failure removes both `.new` files; canonical state untouched.
- [x] `unusedKeyStateNote`-equivalent messaging points at the `.pre-rotate` backups and suggests `shred -u`.

## Notable design choices
- **Single source of truth for env var → prompt mapping.** `runRotateMasterPassword` takes a `passwordPromptConfig` parameter rather than reading env vars itself; production passes `resolvePasswordPrompt()`, tests pass a sequenced prompt that returns old-pw, new-pw, new-pw in order.
- **Library-level path override is `NewMasterPasswordSourceAtPath`.** The existing `NewMasterPasswordSource(dataDir, ...)` becomes a thin wrapper joining the canonical filename. No call sites changed signature.
- **Lock-file cleanup uses a "sidecar exists" invariant rather than tracking success/error explicitly.** In `initializeLocked`'s deferred cleanup, the lock file is removed only when re-stat shows the sidecar present. This is correct in both directions:
  - Sidecar exists ⇒ no future invocation will enter `initializeLocked` again (acquireKey short-circuits to `unlock` on a present sidecar), so the sentinel is genuinely orphaned.
  - Sidecar absent ⇒ a concurrent waiter blocked on our flock is about to acquire and depend on the same lock-file inode for serialization. Removing it would let a third arrival open a fresh inode and run `initialize` in parallel — silently broken.
- **Rotation-staging cleanup is unconditional in the rotation rollback path.** Rotation is single-process; no concurrent waiter is depending on `passwords.key.new.lock` for anything. Belt-and-braces removal in both rollback and (idempotently) post-commit.

## Test plan
- [x] `go test ./...` — full suite passes.
- [x] `golangci-lint run ./...` — clean.
- [x] `go test ./internal/database/ -race -run TestMasterPasswordSource_ConcurrentFirstRun -count=10` — 10 iterations under race detector, all pass. This is the safety regression check for the canonical-lock cleanup.
- [x] Manual smoke test in fresh `HOME` with `SESH_BACKEND=sqlite SESH_KEY_SOURCE=password`:
  - First-init no longer leaves `passwords.key.lock` on disk.
  - Happy-path rotation: `Master password:` + `y` + `Create master password:` + `Confirm master password:` → succeeds, `.pre-rotate` backups present, no `.lock` files.
  - New password unlocks the rotated DB; old password rejected.
  - Cancel at confirmation: DB unchanged, no staging files left over.
  - Refuse when staging file from a prior attempt exists.
  - Mismatched-confirm on new password: rollback removes `.new` sidecar AND `.new.lock`, error message names what failed.
  - Init-error path (mismatched confirm during first-init) preserves `passwords.key.lock` — verified by `TestInitializeLocked_PreservesLockFileWhenInitFails`.

## TDD trail (for reviewers)
This branch was developed test-first for the lock-cleanup work — every cleanup commit was preceded by failing tests pinning the desired post-condition AND any safety property the cleanup might break.
- Phase 1 (rotation `.new.lock`): 3 tests asserting cleanup on success / mismatched-confirm rollback / cancel.
- Phase 2 (canonical `.lock`): 1 test asserting cleanup after first-init success + 1 test asserting preservation when first-init errors. The preservation test is the safety-property guard against any future "let's also clean up on error paths" PR.

## Out of scope
- **Flavor B** (`keychain → keychain` rotation of the random keychain key). Distinct failure modes (no atomic rename for keychain entries) and lower priority than the agent work that this branch unblocks. Tracked in `docs/KEY_ROTATION_ROADMAP.md`.
- **KDF parameter upgrades.** Rotation reuses the same Argon2id params as the original sidecar. Bumping cost is a separate "upgrade" operation, also tracked in the roadmap.
- **First-init create+confirm retry.** Mismatched confirm on first-init still fails the whole invocation; only `unlock()` retries. Documented on `WithMaxAttempts` in `master_password.go`. Same scope decision as the retry-loop PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Master password rotation: in-place re-encryption under a new password with atomic DB swap, `.pre-rotate` backups retained, and interactive confirmation before committing.

* **Bug Fixes**
  * Refuses to proceed if leftover staging/backup artifacts exist; ensures lockfile/staging cleanup and safe rollback on failures or user cancellation.

* **Documentation**
  * Added "Rotating your master password" detailing rotation, backups, rollback, and safety behavior.

* **Tests**
  * Expanded rotation tests covering success, rollback, cancellation, preflight refusals, and lock cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->