### PR TITLE
Add sesh agent daemon skeleton (Phase A of agent initiative)

### DIFF
--- a/internal/agent/closer.go
+++ b/internal/agent/closer.go
@@ -1,0 +1,16 @@
+package agent
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+// closeOrLog closes c, surfacing any error as a stderr warning. Used in
+// defer chains where the close failure isn't actionable (the primary
+// path already errored) but we don't want to silently swallow it either.
+func closeOrLog(c io.Closer, what string) {
+	if err := c.Close(); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: close %s: %v\n", what, err) //nolint:errcheck // best-effort warning to stderr
+	}
+}

--- a/internal/agent/closer_test.go
+++ b/internal/agent/closer_test.go
@@ -1,0 +1,26 @@
+package agent
+
+import (
+	"errors"
+	"testing"
+)
+
+// errCloser is a test io.Closer that returns a configurable error.
+type errCloser struct {
+	err error
+}
+
+func (c *errCloser) Close() error { return c.err }
+
+func TestCloseOrLog_SilentOnSuccess(t *testing.T) {
+	// Just confirming the function runs without panic when Close
+	// succeeds; closeOrLog has no return so there's nothing else to
+	// assert here without capturing stderr.
+	closeOrLog(&errCloser{err: nil}, "noop")
+}
+
+func TestCloseOrLog_SurvivesCloseError(t *testing.T) {
+	// closeOrLog must not panic or propagate when Close errors; the
+	// warning goes to stderr.
+	closeOrLog(&errCloser{err: errors.New("boom")}, "noop")
+}

--- a/internal/agent/handshake_test.go
+++ b/internal/agent/handshake_test.go
@@ -1,0 +1,141 @@
+package agent
+
+import (
+	"bufio"
+	"errors"
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeAgentBehavior is what the fake-agent helper does on its single
+// connection. Behaviors get t so they can surface errors via t.Logf
+// without us needing to silently discard them.
+type fakeAgentBehavior func(t *testing.T, rw *bufio.ReadWriter)
+
+// startFakeAgent spins up a listener on a fresh socket path, accepts one
+// connection, and lets behavior drive the responses. Returns the socket
+// path; the listener is closed on test cleanup.
+func startFakeAgent(t *testing.T, behavior fakeAgentBehavior) string {
+	t.Helper()
+	sockPath := tempSocketPath(t)
+	addr, err := net.ResolveUnixAddr("unix", sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lis, err := net.ListenUnix("unix", addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { mustClose(t, lis) })
+
+	go func() {
+		conn, aerr := lis.AcceptUnix()
+		if aerr != nil {
+			return // listener closed via t.Cleanup
+		}
+		defer mustClose(t, conn)
+		if derr := conn.SetDeadline(time.Now().Add(2 * time.Second)); derr != nil {
+			t.Logf("fake agent set deadline: %v", derr)
+		}
+		rw := bufio.NewReadWriter(bufio.NewReader(conn), bufio.NewWriter(conn))
+		behavior(t, rw)
+		if ferr := rw.Flush(); ferr != nil {
+			t.Logf("fake agent flush: %v", ferr)
+		}
+	}()
+	return sockPath
+}
+
+// consumeClientHello reads the first newline-terminated message from rw
+// (the client's hello) and discards it. Logs but otherwise ignores any
+// read error — the test cares about what the fake agent SENDS, not what
+// the client said.
+func consumeClientHello(t *testing.T, rw *bufio.ReadWriter) {
+	t.Helper()
+	if _, err := rw.ReadBytes('\n'); err != nil {
+		t.Logf("fake agent consume hello: %v", err)
+	}
+}
+
+// reply writes resp to rw, logging any write error.
+func reply(t *testing.T, rw *bufio.ReadWriter, resp any) {
+	t.Helper()
+	if err := writeJSON(rw, resp); err != nil {
+		t.Logf("fake agent write response: %v", err)
+	}
+}
+
+func TestDialAndHandshake_AgentVersionMismatch(t *testing.T) {
+	sockPath := startFakeAgent(t, func(t *testing.T, rw *bufio.ReadWriter) {
+		consumeClientHello(t, rw)
+		reply(t, rw, HelloResponse{Type: TypeHelloAck, Version: 99, AgentPID: 1})
+	})
+	_, err := dialAndHandshake(sockPath)
+	if err == nil {
+		t.Fatal("dialAndHandshake should fail on version mismatch")
+	}
+	if !strings.Contains(err.Error(), "version") {
+		t.Errorf("err = %v, want version-mismatch message", err)
+	}
+}
+
+func TestDialAndHandshake_AgentReturnsError(t *testing.T) {
+	sockPath := startFakeAgent(t, func(t *testing.T, rw *bufio.ReadWriter) {
+		consumeClientHello(t, rw)
+		reply(t, rw, ErrorResponse{
+			Type:    TypeError,
+			Version: ProtocolVersion,
+			Code:    ErrCodePeerCredMismatch,
+			Message: "fake-agent peer-cred check failed",
+		})
+	})
+	_, err := dialAndHandshake(sockPath)
+	if err == nil {
+		t.Fatal("dialAndHandshake should fail when agent returns error")
+	}
+	if !strings.Contains(err.Error(), ErrCodePeerCredMismatch) {
+		t.Errorf("err = %v, want code mention", err)
+	}
+}
+
+func TestDialAndHandshake_UnexpectedResponseType(t *testing.T) {
+	sockPath := startFakeAgent(t, func(t *testing.T, rw *bufio.ReadWriter) {
+		consumeClientHello(t, rw)
+		reply(t, rw, struct {
+			Type    string `json:"type"`
+			Version int    `json:"version"`
+		}{Type: "banana", Version: ProtocolVersion})
+	})
+	_, err := dialAndHandshake(sockPath)
+	if err == nil {
+		t.Fatal("dialAndHandshake should fail on unexpected response type")
+	}
+	if !strings.Contains(err.Error(), "unexpected response type") {
+		t.Errorf("err = %v, want unexpected-type message", err)
+	}
+}
+
+func TestDialAndHandshake_AgentClosesBeforeAck(t *testing.T) {
+	sockPath := startFakeAgent(t, func(t *testing.T, rw *bufio.ReadWriter) {
+		// Read the hello but never reply — connection closes when
+		// the goroutine exits.
+		consumeClientHello(t, rw)
+	})
+	_, err := dialAndHandshake(sockPath)
+	if err == nil {
+		t.Fatal("dialAndHandshake should fail when agent never sends hello_ack")
+	}
+	if !errors.Is(err, io.EOF) && !strings.Contains(err.Error(), "read hello_ack") {
+		t.Errorf("err = %v, want read-error wrapping io.EOF", err)
+	}
+}
+
+func TestDialAndHandshake_FailsOnMissingSocket(t *testing.T) {
+	_, err := dialAndHandshake("/tmp/definitely-does-not-exist.sock")
+	if err == nil {
+		t.Fatal("dialAndHandshake should fail on missing socket")
+	}
+}

--- a/internal/agent/paths.go
+++ b/internal/agent/paths.go
@@ -1,0 +1,54 @@
+// Package agent implements the sesh-agent daemon and its client protocol.
+// The daemon listens on a per-UID Unix socket and serves a versioned
+// JSON-over-newline protocol; clients (the sesh CLI) auto-spawn it on
+// demand when SESH_KEY_SOURCE=password is in use.
+package agent
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// SocketPath returns the canonical Unix-socket path that both the daemon
+// and its clients use to find each other. Resolves under os.UserCacheDir
+// so it's per-user (no cross-user collisions) and ephemeral by convention.
+//
+// Override via the SESH_AUTH_SOCK env var for containers / multi-instance
+// dev setups; most users never touch it.
+func SocketPath() (string, error) {
+	if override := os.Getenv("SESH_AUTH_SOCK"); override != "" {
+		return override, nil
+	}
+	cache, err := os.UserCacheDir()
+	if err != nil {
+		return "", fmt.Errorf("locate user cache dir: %w", err)
+	}
+	dir := filepath.Join(cache, "sesh")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("create agent dir %s: %w", dir, err)
+	}
+	return filepath.Join(dir, "agent.sock"), nil
+}
+
+// LogPath returns the file the auto-spawned agent's stderr is redirected
+// to. Kept separate from the socket path: socket lives in cache dir
+// (ephemeral, OS may clean), logs live in a state dir (persistent across
+// reboots so post-mortem debugging works).
+func LogPath() (string, error) {
+	cache, err := os.UserCacheDir()
+	if err != nil {
+		return "", fmt.Errorf("locate user cache dir: %w", err)
+	}
+	// macOS conventions put logs under ~/Library/Logs/sesh; Linux's XDG
+	// state dir is the analog. os.UserCacheDir() returns paths under
+	// ~/Library/Caches on macOS and $XDG_CACHE_HOME on Linux — using
+	// a sibling "logs" directory under the same parent keeps platform
+	// branching out of this function while still landing in a sensible
+	// location on each.
+	dir := filepath.Join(cache, "sesh", "logs")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("create agent log dir %s: %w", dir, err)
+	}
+	return filepath.Join(dir, "agent.log"), nil
+}

--- a/internal/agent/paths_test.go
+++ b/internal/agent/paths_test.go
@@ -1,0 +1,39 @@
+package agent
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSocketPath_HonorsAuthSockOverride(t *testing.T) {
+	t.Setenv("SESH_AUTH_SOCK", "/tmp/explicit.sock")
+	got, err := SocketPath()
+	if err != nil {
+		t.Fatalf("SocketPath: %v", err)
+	}
+	if got != "/tmp/explicit.sock" {
+		t.Errorf("SocketPath = %q, want /tmp/explicit.sock", got)
+	}
+}
+
+func TestSocketPath_DefaultsUnderUserCacheDir(t *testing.T) {
+	t.Setenv("SESH_AUTH_SOCK", "")
+	got, err := SocketPath()
+	if err != nil {
+		t.Fatalf("SocketPath: %v", err)
+	}
+	if !strings.HasSuffix(got, filepath.Join("sesh", "agent.sock")) {
+		t.Errorf("SocketPath = %q, want suffix sesh/agent.sock", got)
+	}
+}
+
+func TestLogPath_UnderUserCacheLogsDir(t *testing.T) {
+	got, err := LogPath()
+	if err != nil {
+		t.Fatalf("LogPath: %v", err)
+	}
+	if !strings.HasSuffix(got, filepath.Join("sesh", "logs", "agent.log")) {
+		t.Errorf("LogPath = %q, want suffix sesh/logs/agent.log", got)
+	}
+}

--- a/internal/agent/peercred_darwin.go
+++ b/internal/agent/peercred_darwin.go
@@ -1,0 +1,20 @@
+//go:build darwin
+
+package agent
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+// readPeerUID returns the connecting peer's UID via LOCAL_PEERCRED. The
+// xucred struct's Uid field carries the effective UID of the peer at
+// connect(2) time.
+func readPeerUID(fd int) (uint32, error) {
+	xucred, err := unix.GetsockoptXucred(fd, unix.SOL_LOCAL, unix.LOCAL_PEERCRED)
+	if err != nil {
+		return 0, fmt.Errorf("getsockopt LOCAL_PEERCRED: %w", err)
+	}
+	return xucred.Uid, nil
+}

--- a/internal/agent/peercred_linux.go
+++ b/internal/agent/peercred_linux.go
@@ -1,0 +1,20 @@
+//go:build linux
+
+package agent
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+// readPeerUID returns the connecting peer's UID via SO_PEERCRED. The
+// kernel populates this from the credentials present at connect(2) time,
+// so a process that re-exec()'d into another UID is reflected here.
+func readPeerUID(fd int) (uint32, error) {
+	cred, err := unix.GetsockoptUcred(fd, unix.SOL_SOCKET, unix.SO_PEERCRED)
+	if err != nil {
+		return 0, fmt.Errorf("getsockopt SO_PEERCRED: %w", err)
+	}
+	return cred.Uid, nil
+}

--- a/internal/agent/peercred_other.go
+++ b/internal/agent/peercred_other.go
@@ -1,0 +1,16 @@
+//go:build !linux && !darwin
+
+package agent
+
+import (
+	"fmt"
+	"net"
+)
+
+// checkPeerCred is a build-stub for platforms sesh-agent doesn't support.
+// The package still compiles on those platforms so callers can import it
+// without build-tagging their own files, but any actual use returns an
+// error at runtime.
+func checkPeerCred(_ *net.UnixConn) error {
+	return fmt.Errorf("peer credential check not implemented on this platform")
+}

--- a/internal/agent/peercred_unix.go
+++ b/internal/agent/peercred_unix.go
@@ -1,0 +1,50 @@
+//go:build linux || darwin
+
+package agent
+
+import (
+	"fmt"
+	"net"
+	"os"
+)
+
+// checkPeerCred returns nil iff the connection is from the same UID as
+// the agent process. Otherwise an error suitable for logging and
+// closing the connection.
+//
+// The socket file is mode 0600, so cross-UID connect attempts should
+// already be denied by the filesystem — this check is defense-in-depth
+// against permission misconfiguration, bind-mount weirdness, or future
+// changes that loosen the directory permissions.
+func checkPeerCred(conn *net.UnixConn) error {
+	uid, err := peerUID(conn)
+	if err != nil {
+		return fmt.Errorf("read peer cred: %w", err)
+	}
+	if uid != uint32(os.Getuid()) { //nolint:gosec // os.Getuid returns int but UIDs are non-negative
+		return fmt.Errorf("peer UID %d != agent UID %d", uid, os.Getuid())
+	}
+	return nil
+}
+
+// peerUID extracts the connecting process's UID from a Unix socket.
+// Uses SO_PEERCRED on Linux and LOCAL_PEERCRED on macOS — both surfaced
+// by golang.org/x/sys/unix.GetsockoptUcred / GetsockoptXucred.
+func peerUID(conn *net.UnixConn) (uint32, error) {
+	raw, err := conn.SyscallConn()
+	if err != nil {
+		return 0, fmt.Errorf("syscall conn: %w", err)
+	}
+	var uid uint32
+	var cerr error
+	ctlErr := raw.Control(func(fd uintptr) {
+		uid, cerr = readPeerUID(int(fd))
+	})
+	if ctlErr != nil {
+		return 0, ctlErr
+	}
+	if cerr != nil {
+		return 0, cerr
+	}
+	return uid, nil
+}

--- a/internal/agent/protocol.go
+++ b/internal/agent/protocol.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 )
@@ -97,11 +98,19 @@ func writeJSON(w io.Writer, v any) error {
 // decodes only its envelope (type + version). Callers then unmarshal
 // the raw line into the concrete request struct via decodeMessage.
 //
-// io.EOF (i.e. peer closed cleanly) is returned unwrapped so callers
-// can distinguish "normal disconnect" from "malformed input."
+// io.EOF (peer closed cleanly with no partial frame) is returned
+// unwrapped so callers can distinguish "normal disconnect" from
+// "truncated frame" / "malformed input."
 func readEnvelope(r *bufio.Reader) (env envelope, raw []byte, err error) {
 	line, err := r.ReadBytes('\n')
 	if err != nil {
+		// bufio returns (partial-data, io.EOF) when the peer closed
+		// mid-frame. Partial data with no terminator is a protocol
+		// violation, not a clean disconnect — surface as a wrapped
+		// ErrUnexpectedEOF so isCleanDisconnect routes it correctly.
+		if errors.Is(err, io.EOF) && len(line) > 0 {
+			return envelope{}, line, fmt.Errorf("truncated frame (%d bytes, no terminator): %w", len(line), io.ErrUnexpectedEOF)
+		}
 		return envelope{}, nil, err
 	}
 	// ReadBytes includes the terminator; json.Unmarshal handles it fine

--- a/internal/agent/protocol.go
+++ b/internal/agent/protocol.go
@@ -1,0 +1,123 @@
+package agent
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// ProtocolVersion is the on-wire schema version. A version mismatch
+// between client and agent is fatal; both sides close the connection
+// after writing/reading the error.
+//
+// Versioning rule: bump on any change that breaks the wire format
+// (new required field, type change, removed message). Adding optional
+// fields with omitempty does not require a bump.
+const ProtocolVersion = 1
+
+// Message-type sentinels. Centralised so the dispatch and the message
+// structs can't drift apart.
+const (
+	TypeHello    = "hello"
+	TypeHelloAck = "hello_ack"
+	TypePing     = "ping"
+	TypePong     = "pong"
+	TypeError    = "error"
+)
+
+// Error codes returned in ErrorResponse.Code. Strings (not ints) so they
+// survive log greps and don't require a shared enum file.
+const (
+	ErrCodeProtocolVersionMismatch = "protocol_version_mismatch"
+	ErrCodeUnknownMessageType      = "unknown_message_type"
+	ErrCodePeerCredMismatch        = "peer_cred_mismatch"
+	ErrCodeInternal                = "internal_error"
+)
+
+// envelope is the shared shell every message wears. Used during
+// dispatch to decide what to unmarshal into.
+type envelope struct {
+	Type    string `json:"type"`
+	Version int    `json:"version"`
+}
+
+// HelloRequest is the mandatory first message on every connection. The
+// agent rejects any other type as a first message.
+type HelloRequest struct {
+	Type    string `json:"type"`    // TypeHello
+	Version int    `json:"version"` // ProtocolVersion
+}
+
+// HelloResponse is the agent's reply to a successful handshake. AgentPID
+// is informational — useful for status / debugging, not security-critical.
+type HelloResponse struct {
+	Type     string `json:"type"`      // TypeHelloAck
+	Version  int    `json:"version"`   // server's ProtocolVersion
+	AgentPID int    `json:"agent_pid"` // os.Getpid() of the agent
+}
+
+// PingRequest is a liveness check with no payload. The agent replies
+// with PingResponse.
+type PingRequest struct {
+	Type    string `json:"type"`    // TypePing
+	Version int    `json:"version"` // ProtocolVersion
+}
+
+// PingResponse is the agent's reply to a Ping.
+type PingResponse struct {
+	Type    string `json:"type"` // TypePong
+	Version int    `json:"version"`
+}
+
+// ErrorResponse is returned in place of any expected response when the
+// request can't be served. Code is machine-readable; Message is for the
+// log file / human eyes.
+type ErrorResponse struct {
+	Type    string `json:"type"` // TypeError
+	Code    string `json:"code"`
+	Message string `json:"message"`
+	Version int    `json:"version"`
+}
+
+// writeJSON marshals v and writes it as one line (no embedded newline)
+// followed by '\n' so the peer's bufio.ReadString('\n') frames cleanly.
+func writeJSON(w io.Writer, v any) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("marshal %T: %w", v, err)
+	}
+	if _, err := w.Write(append(b, '\n')); err != nil {
+		return fmt.Errorf("write %T: %w", v, err)
+	}
+	return nil
+}
+
+// readEnvelope reads one newline-terminated JSON message from r and
+// decodes only its envelope (type + version). Callers then unmarshal
+// the raw line into the concrete request struct via decodeMessage.
+//
+// io.EOF (i.e. peer closed cleanly) is returned unwrapped so callers
+// can distinguish "normal disconnect" from "malformed input."
+func readEnvelope(r *bufio.Reader) (env envelope, raw []byte, err error) {
+	line, err := r.ReadBytes('\n')
+	if err != nil {
+		return envelope{}, nil, err
+	}
+	// ReadBytes includes the terminator; json.Unmarshal handles it fine
+	// (trailing whitespace is ignored), so we don't trim.
+	if err := json.Unmarshal(line, &env); err != nil {
+		return envelope{}, line, fmt.Errorf("parse envelope: %w", err)
+	}
+	return env, line, nil
+}
+
+// decodeMessage unmarshals raw (a previously-read message line) into
+// dst. Used by the dispatch after readEnvelope tells us which concrete
+// type to expect.
+func decodeMessage(raw []byte, dst any) error {
+	if err := json.Unmarshal(raw, dst); err != nil {
+		return fmt.Errorf("parse %T: %w", dst, err)
+	}
+	return nil
+}

--- a/internal/agent/protocol_test.go
+++ b/internal/agent/protocol_test.go
@@ -1,0 +1,127 @@
+package agent
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestWriteJSON_AppendsNewlineFraming(t *testing.T) {
+	var buf bytes.Buffer
+	if err := writeJSON(&buf, HelloRequest{Type: TypeHello, Version: ProtocolVersion}); err != nil {
+		t.Fatalf("writeJSON: %v", err)
+	}
+	out := buf.Bytes()
+	if len(out) == 0 || out[len(out)-1] != '\n' {
+		t.Fatalf("writeJSON output not newline-terminated: %q", string(out))
+	}
+	if bytes.Count(out, []byte{'\n'}) != 1 {
+		t.Fatalf("writeJSON output has %d newlines, want exactly 1: %q", bytes.Count(out, []byte{'\n'}), string(out))
+	}
+}
+
+func TestReadEnvelope_DecodesTypeAndVersion(t *testing.T) {
+	line := `{"type":"hello","version":1}` + "\n"
+	r := bufio.NewReader(strings.NewReader(line))
+	env, raw, err := readEnvelope(r)
+	if err != nil {
+		t.Fatalf("readEnvelope: %v", err)
+	}
+	if env.Type != TypeHello {
+		t.Errorf("Type = %q, want %q", env.Type, TypeHello)
+	}
+	if env.Version != ProtocolVersion {
+		t.Errorf("Version = %d, want %d", env.Version, ProtocolVersion)
+	}
+	if !bytes.HasPrefix(raw, []byte(`{"type"`)) {
+		t.Errorf("raw line should preserve original bytes, got %q", string(raw))
+	}
+}
+
+func TestReadEnvelope_ReturnsEOFOnCleanDisconnect(t *testing.T) {
+	r := bufio.NewReader(strings.NewReader(""))
+	_, _, err := readEnvelope(r)
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("readEnvelope on empty input err = %v, want io.EOF", err)
+	}
+}
+
+func TestReadEnvelope_RejectsMalformedJSON(t *testing.T) {
+	r := bufio.NewReader(strings.NewReader("not json\n"))
+	_, _, err := readEnvelope(r)
+	if err == nil {
+		t.Fatal("readEnvelope accepted malformed JSON")
+	}
+	if errors.Is(err, io.EOF) {
+		t.Fatalf("malformed JSON err shouldn't be io.EOF, got %v", err)
+	}
+}
+
+func TestRoundTrip_AllMessageTypes(t *testing.T) {
+	cases := []any{
+		HelloRequest{Type: TypeHello, Version: ProtocolVersion},
+		HelloResponse{Type: TypeHelloAck, Version: ProtocolVersion, AgentPID: 12345},
+		PingRequest{Type: TypePing, Version: ProtocolVersion},
+		PingResponse{Type: TypePong, Version: ProtocolVersion},
+		ErrorResponse{Type: TypeError, Version: ProtocolVersion, Code: ErrCodeUnknownMessageType, Message: "type \"banana\" not recognized"},
+	}
+	for _, msg := range cases {
+		var buf bytes.Buffer
+		if err := writeJSON(&buf, msg); err != nil {
+			t.Errorf("writeJSON %T: %v", msg, err)
+			continue
+		}
+		r := bufio.NewReader(&buf)
+		env, raw, err := readEnvelope(r)
+		if err != nil {
+			t.Errorf("readEnvelope %T: %v", msg, err)
+			continue
+		}
+		if env.Version != ProtocolVersion {
+			t.Errorf("%T: round-tripped version = %d, want %d", msg, env.Version, ProtocolVersion)
+		}
+		switch msg.(type) {
+		case HelloRequest:
+			var got HelloRequest
+			if err := decodeMessage(raw, &got); err != nil {
+				t.Errorf("decode HelloRequest: %v", err)
+			}
+		case HelloResponse:
+			var got HelloResponse
+			if err := decodeMessage(raw, &got); err != nil {
+				t.Errorf("decode HelloResponse: %v", err)
+			} else if got.AgentPID != 12345 {
+				t.Errorf("HelloResponse.AgentPID = %d, want 12345", got.AgentPID)
+			}
+		case PingRequest:
+			var got PingRequest
+			if err := decodeMessage(raw, &got); err != nil {
+				t.Errorf("decode PingRequest: %v", err)
+			}
+		case PingResponse:
+			var got PingResponse
+			if err := decodeMessage(raw, &got); err != nil {
+				t.Errorf("decode PingResponse: %v", err)
+			}
+		case ErrorResponse:
+			var got ErrorResponse
+			if err := decodeMessage(raw, &got); err != nil {
+				t.Errorf("decode ErrorResponse: %v", err)
+			} else if got.Code != ErrCodeUnknownMessageType {
+				t.Errorf("ErrorResponse.Code = %q, want %q", got.Code, ErrCodeUnknownMessageType)
+			}
+		}
+	}
+}
+
+func TestProtocolVersion_IsStable(t *testing.T) {
+	// Bumping ProtocolVersion is intentional but must be a conscious
+	// decision — this test makes the bump visible in code review.
+	const expected = 1
+	if ProtocolVersion != expected {
+		t.Fatalf("ProtocolVersion changed to %d; if intentional, update this test and SESH_AGENT_PHASE_*_PLAN.md / SECURITY_MODEL.md as needed", ProtocolVersion)
+	}
+}

--- a/internal/agent/protocol_test.go
+++ b/internal/agent/protocol_test.go
@@ -49,6 +49,20 @@ func TestReadEnvelope_ReturnsEOFOnCleanDisconnect(t *testing.T) {
 	}
 }
 
+func TestReadEnvelope_TruncatedFrame_ReturnsError(t *testing.T) {
+	r := bufio.NewReader(strings.NewReader(`{"type":"hello","version":1`))
+	_, _, err := readEnvelope(r)
+	if err == nil {
+		t.Fatal("readEnvelope accepted a truncated frame")
+	}
+	if errors.Is(err, io.EOF) {
+		t.Fatalf("truncated frame should not be reported as clean EOF, got %v", err)
+	}
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Errorf("truncated frame should wrap io.ErrUnexpectedEOF, got %v", err)
+	}
+}
+
 func TestReadEnvelope_RejectsMalformedJSON(t *testing.T) {
 	r := bufio.NewReader(strings.NewReader("not json\n"))
 	_, _, err := readEnvelope(r)

--- a/internal/agent/server.go
+++ b/internal/agent/server.go
@@ -1,0 +1,210 @@
+package agent
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+)
+
+// Server owns the listening socket and dispatches incoming connections
+// to per-connection handler goroutines.
+type Server struct {
+	shutdownErr error
+	listener    *net.UnixListener
+	sockPath    string
+	// shutdownOnce guards Close so concurrent SIGTERM + accept-loop-exit
+	// don't try to remove the socket twice.
+	shutdownOnce sync.Once
+}
+
+// Listen creates the socket at sockPath, sets perm 0600, and returns a
+// Server ready to Run. If a stale socket file exists from a prior
+// crashed agent, Listen removes it before binding — but only after
+// confirming no live agent is actually answering on it.
+func Listen(sockPath string) (*Server, error) {
+	if _, err := os.Stat(sockPath); err == nil {
+		// File exists. Distinguish "stale file from prior crash" from
+		// "another agent is running" by trying to connect.
+		if conn, derr := net.DialTimeout("unix", sockPath, dialTimeout); derr == nil {
+			closeOrLog(conn, "probe connection")
+			return nil, fmt.Errorf("agent already running at %s", sockPath)
+		}
+		if rerr := os.Remove(sockPath); rerr != nil {
+			return nil, fmt.Errorf("remove stale socket %s: %w", sockPath, rerr)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("stat socket %s: %w", sockPath, err)
+	}
+
+	laddr, err := net.ResolveUnixAddr("unix", sockPath)
+	if err != nil {
+		return nil, fmt.Errorf("resolve unix addr: %w", err)
+	}
+	lis, err := net.ListenUnix("unix", laddr)
+	if err != nil {
+		return nil, fmt.Errorf("listen %s: %w", sockPath, err)
+	}
+	if err := os.Chmod(sockPath, 0o600); err != nil {
+		closeOrLog(lis, "listener after chmod failure")
+		if rerr := os.Remove(sockPath); rerr != nil && !errors.Is(rerr, os.ErrNotExist) {
+			return nil, fmt.Errorf("chmod socket: %w (cleanup also failed: %v)", err, rerr)
+		}
+		return nil, fmt.Errorf("chmod socket: %w", err)
+	}
+	return &Server{sockPath: sockPath, listener: lis}, nil
+}
+
+// SocketPath returns the path the server is bound to. Useful for tests
+// and `sesh agent status` introspection in later phases.
+func (s *Server) SocketPath() string {
+	return s.sockPath
+}
+
+// Run blocks until ctx is cancelled or SIGTERM/SIGINT arrives, accepting
+// connections and dispatching them on per-connection goroutines. On exit
+// it closes the listener and removes the socket file.
+func (s *Server) Run(ctx context.Context) error {
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+	defer signal.Stop(sigCh)
+
+	go func() {
+		select {
+		case <-ctx.Done():
+		case <-sigCh:
+		}
+		if err := s.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: agent shutdown: %v\n", err) //nolint:errcheck // best-effort warning
+		}
+	}()
+
+	for {
+		conn, err := s.listener.AcceptUnix()
+		if err != nil {
+			// Listener closed during shutdown produces a net.ErrClosed
+			// or equivalent; treat that as a clean exit, not an error.
+			if errors.Is(err, net.ErrClosed) {
+				return nil
+			}
+			return fmt.Errorf("accept: %w", err)
+		}
+		go s.handleConn(conn)
+	}
+}
+
+// Close shuts down the server: stops accepting, removes the socket file.
+// Safe to call multiple times; subsequent calls are no-ops.
+func (s *Server) Close() error {
+	s.shutdownOnce.Do(func() {
+		if cerr := s.listener.Close(); cerr != nil && !errors.Is(cerr, net.ErrClosed) {
+			s.shutdownErr = fmt.Errorf("close listener: %w", cerr)
+		}
+		if rerr := os.Remove(s.sockPath); rerr != nil && !errors.Is(rerr, os.ErrNotExist) {
+			if s.shutdownErr == nil {
+				s.shutdownErr = fmt.Errorf("remove socket: %w", rerr)
+			}
+		}
+	})
+	return s.shutdownErr
+}
+
+// handleConn services one client connection: peer-cred check, hello
+// handshake, then ping until the peer disconnects or sends an unknown
+// message. Each connection runs on its own goroutine; handleConn closes
+// the connection on exit.
+func (s *Server) handleConn(conn *net.UnixConn) {
+	defer closeOrLog(conn, "client connection")
+
+	if err := checkPeerCred(conn); err != nil {
+		sendErrorAndIgnore(conn, ErrCodePeerCredMismatch, err.Error())
+		return
+	}
+
+	r := bufio.NewReader(conn)
+
+	// First message must be hello.
+	env, raw, err := readEnvelope(r)
+	if err != nil {
+		if !isCleanDisconnect(err) {
+			sendErrorAndIgnore(conn, ErrCodeInternal, err.Error())
+		}
+		return
+	}
+	if env.Type != TypeHello {
+		sendErrorAndIgnore(conn, ErrCodeUnknownMessageType,
+			fmt.Sprintf("first message must be %q, got %q", TypeHello, env.Type))
+		return
+	}
+	if env.Version != ProtocolVersion {
+		sendErrorAndIgnore(conn, ErrCodeProtocolVersionMismatch,
+			fmt.Sprintf("client version %d, server %d", env.Version, ProtocolVersion))
+		return
+	}
+	var hello HelloRequest
+	if err := decodeMessage(raw, &hello); err != nil {
+		sendErrorAndIgnore(conn, ErrCodeInternal, err.Error())
+		return
+	}
+	if err := writeJSON(conn, HelloResponse{
+		Type:     TypeHelloAck,
+		Version:  ProtocolVersion,
+		AgentPID: os.Getpid(),
+	}); err != nil {
+		return
+	}
+
+	// Subsequent messages.
+	for {
+		env, _, err := readEnvelope(r)
+		if err != nil {
+			return
+		}
+		switch env.Type {
+		case TypePing:
+			if err := writeJSON(conn, PingResponse{
+				Type:    TypePong,
+				Version: ProtocolVersion,
+			}); err != nil {
+				return
+			}
+		default:
+			if err := writeJSON(conn, ErrorResponse{
+				Type:    TypeError,
+				Version: ProtocolVersion,
+				Code:    ErrCodeUnknownMessageType,
+				Message: fmt.Sprintf("type %q not recognized", env.Type),
+			}); err != nil {
+				return
+			}
+		}
+	}
+}
+
+// sendErrorAndIgnore writes an ErrorResponse and silently discards any
+// write failure — by the time we're sending an error, the client has
+// already misbehaved or the connection is dying, so the secondary
+// failure isn't actionable.
+func sendErrorAndIgnore(conn *net.UnixConn, code, message string) {
+	if err := writeJSON(conn, ErrorResponse{
+		Type:    TypeError,
+		Version: ProtocolVersion,
+		Code:    code,
+		Message: message,
+	}); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: write error response: %v\n", err) //nolint:errcheck // best-effort warning
+	}
+}
+
+// isCleanDisconnect reports whether err is a "peer closed the connection
+// without sending any data" — i.e. a normal end-of-conversation, not a
+// protocol error worth reporting.
+func isCleanDisconnect(err error) bool {
+	return errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF)
+}

--- a/internal/agent/server.go
+++ b/internal/agent/server.go
@@ -204,7 +204,9 @@ func sendErrorAndIgnore(conn *net.UnixConn, code, message string) {
 
 // isCleanDisconnect reports whether err is a "peer closed the connection
 // without sending any data" — i.e. a normal end-of-conversation, not a
-// protocol error worth reporting.
+// protocol error worth reporting. io.ErrUnexpectedEOF is deliberately
+// excluded: it means the peer closed mid-frame, which is a protocol
+// violation we want to log via the regular error path.
 func isCleanDisconnect(err error) bool {
-	return errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF)
+	return errors.Is(err, io.EOF)
 }

--- a/internal/agent/server_test.go
+++ b/internal/agent/server_test.go
@@ -1,0 +1,358 @@
+package agent
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// tempSocketPath returns a short path suitable for binding a Unix socket.
+// macOS caps socket paths at 104 chars and t.TempDir() lives under
+// /var/folders/.../TestName.../NNN which by itself can exceed the limit
+// once the test name is long. Using /tmp directly keeps us under it.
+func tempSocketPath(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "sa")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() {
+		if rerr := os.RemoveAll(dir); rerr != nil {
+			t.Errorf("RemoveAll(%s): %v", dir, rerr)
+		}
+	})
+	return filepath.Join(dir, "s")
+}
+
+// mustClose closes c, failing the test if Close returns an error. Used
+// in place of `defer func() { _ = c.Close() }()` so errcheck stays
+// happy without nolint.
+func mustClose(t *testing.T, c io.Closer) {
+	t.Helper()
+	if err := c.Close(); err != nil {
+		t.Errorf("close: %v", err)
+	}
+}
+
+// dialAndShake is a test helper that dials the agent socket and runs the
+// hello handshake. Mirrors what a real CLI client does on connect.
+func dialAndShake(t *testing.T, sockPath string) *net.UnixConn {
+	t.Helper()
+	conn, err := dialAndHandshake(sockPath)
+	if err != nil {
+		t.Fatalf("dialAndHandshake: %v", err)
+	}
+	return conn
+}
+
+// runServer starts a server on its own goroutine and returns a stop
+// function. The caller defers stop() to shut it down.
+func runServer(t *testing.T, sockPath string) func() {
+	t.Helper()
+	srv, err := Listen(sockPath)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		if err := srv.Run(ctx); err != nil {
+			t.Errorf("server Run: %v", err)
+		}
+		close(done)
+	}()
+	return func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Errorf("server Run did not exit within 2s after cancel")
+		}
+	}
+}
+
+func TestServer_HelloHandshake(t *testing.T) {
+	sockPath := tempSocketPath(t)
+	stop := runServer(t, sockPath)
+	defer stop()
+
+	conn := dialAndShake(t, sockPath)
+	defer mustClose(t, conn)
+}
+
+func TestServer_HelloAckIncludesAgentPID(t *testing.T) {
+	sockPath := tempSocketPath(t)
+	stop := runServer(t, sockPath)
+	defer stop()
+
+	raw, err := net.DialTimeout("unix", sockPath, dialTimeout)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	conn := raw.(*net.UnixConn)
+	defer mustClose(t, conn)
+
+	if err := writeJSON(conn, HelloRequest{Type: TypeHello, Version: ProtocolVersion}); err != nil {
+		t.Fatal(err)
+	}
+
+	r := bufio.NewReader(conn)
+	_, raw2, err := readEnvelope(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var ack HelloResponse
+	if err := decodeMessage(raw2, &ack); err != nil {
+		t.Fatal(err)
+	}
+	if ack.Type != TypeHelloAck {
+		t.Errorf("Type = %q, want %q", ack.Type, TypeHelloAck)
+	}
+	if ack.AgentPID != os.Getpid() {
+		t.Errorf("AgentPID = %d, want %d (server runs in test process)", ack.AgentPID, os.Getpid())
+	}
+}
+
+func TestServer_PingPong(t *testing.T) {
+	sockPath := tempSocketPath(t)
+	stop := runServer(t, sockPath)
+	defer stop()
+
+	conn := dialAndShake(t, sockPath)
+	defer mustClose(t, conn)
+
+	if err := writeJSON(conn, PingRequest{Type: TypePing, Version: ProtocolVersion}); err != nil {
+		t.Fatal(err)
+	}
+	r := bufio.NewReader(conn)
+	env, _, err := readEnvelope(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if env.Type != TypePong {
+		t.Errorf("response type = %q, want %q", env.Type, TypePong)
+	}
+}
+
+func TestServer_VersionMismatchRejectsHello(t *testing.T) {
+	sockPath := tempSocketPath(t)
+	stop := runServer(t, sockPath)
+	defer stop()
+
+	raw, err := net.DialTimeout("unix", sockPath, dialTimeout)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	conn := raw.(*net.UnixConn)
+	defer mustClose(t, conn)
+
+	if err := writeJSON(conn, HelloRequest{Type: TypeHello, Version: 99}); err != nil {
+		t.Fatal(err)
+	}
+	r := bufio.NewReader(conn)
+	_, line, err := readEnvelope(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got ErrorResponse
+	if err := decodeMessage(line, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Code != ErrCodeProtocolVersionMismatch {
+		t.Errorf("Code = %q, want %q (full message: %q)", got.Code, ErrCodeProtocolVersionMismatch, got.Message)
+	}
+}
+
+func TestServer_NonHelloFirstMessageRejected(t *testing.T) {
+	sockPath := tempSocketPath(t)
+	stop := runServer(t, sockPath)
+	defer stop()
+
+	raw, err := net.DialTimeout("unix", sockPath, dialTimeout)
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn := raw.(*net.UnixConn)
+	defer mustClose(t, conn)
+
+	if err := writeJSON(conn, PingRequest{Type: TypePing, Version: ProtocolVersion}); err != nil {
+		t.Fatal(err)
+	}
+	r := bufio.NewReader(conn)
+	_, line, err := readEnvelope(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got ErrorResponse
+	if err := decodeMessage(line, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Code != ErrCodeUnknownMessageType {
+		t.Errorf("Code = %q, want %q", got.Code, ErrCodeUnknownMessageType)
+	}
+	if !strings.Contains(got.Message, TypeHello) {
+		t.Errorf("Message %q should mention %q", got.Message, TypeHello)
+	}
+}
+
+func TestServer_UnknownMessageTypeAfterHello(t *testing.T) {
+	sockPath := tempSocketPath(t)
+	stop := runServer(t, sockPath)
+	defer stop()
+
+	conn := dialAndShake(t, sockPath)
+	defer mustClose(t, conn)
+
+	if err := writeJSON(conn, struct {
+		Type    string `json:"type"`
+		Version int    `json:"version"`
+	}{Type: "banana", Version: ProtocolVersion}); err != nil {
+		t.Fatal(err)
+	}
+	r := bufio.NewReader(conn)
+	_, line, err := readEnvelope(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got ErrorResponse
+	if err := decodeMessage(line, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Code != ErrCodeUnknownMessageType {
+		t.Errorf("Code = %q, want %q", got.Code, ErrCodeUnknownMessageType)
+	}
+}
+
+func TestServer_ClientDisconnectMidStreamLeavesServerHealthy(t *testing.T) {
+	sockPath := tempSocketPath(t)
+	stop := runServer(t, sockPath)
+	defer stop()
+
+	conn := dialAndShake(t, sockPath)
+	if err := conn.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	conn2 := dialAndShake(t, sockPath)
+	defer mustClose(t, conn2)
+}
+
+func TestServer_RefusesIfSocketAlreadyBound(t *testing.T) {
+	sockPath := tempSocketPath(t)
+	stop := runServer(t, sockPath)
+	defer stop()
+
+	_, err := Listen(sockPath)
+	if err == nil {
+		t.Fatal("Listen on already-bound socket should fail")
+	}
+	if !strings.Contains(err.Error(), "already running") {
+		t.Errorf("err = %v, want mention of 'already running'", err)
+	}
+}
+
+func TestServer_CleansUpStaleSocketFile(t *testing.T) {
+	sockPath := tempSocketPath(t)
+	if err := os.WriteFile(sockPath, []byte("stale"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(sockPath); err != nil {
+		t.Fatalf("setup: stale file not present: %v", err)
+	}
+
+	srv, err := Listen(sockPath)
+	if err != nil {
+		t.Fatalf("Listen should clean up stale file and succeed: %v", err)
+	}
+	defer mustClose(t, srv)
+}
+
+func TestServer_ShutdownRemovesSocket(t *testing.T) {
+	sockPath := tempSocketPath(t)
+	stop := runServer(t, sockPath)
+	if _, err := os.Stat(sockPath); err != nil {
+		t.Fatalf("socket not bound after Listen: %v", err)
+	}
+	stop()
+	if _, err := os.Stat(sockPath); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("socket file should be removed after shutdown, stat err = %v", err)
+	}
+}
+
+func TestServer_SIGTERMRemovesSocket(t *testing.T) {
+	sockPath := tempSocketPath(t)
+	srv, err := Listen(sockPath)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	done := make(chan error, 1)
+	go func() {
+		done <- srv.Run(context.Background())
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+
+	if err := syscall.Kill(os.Getpid(), syscall.SIGTERM); err != nil {
+		t.Fatalf("send SIGTERM: %v", err)
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Run returned err = %v, want nil after SIGTERM", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("server didn't exit within 2s of SIGTERM")
+	}
+
+	if _, err := os.Stat(sockPath); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("socket file should be removed after SIGTERM, stat err = %v", err)
+	}
+}
+
+func TestServer_HandlesManyConcurrentClients(t *testing.T) {
+	sockPath := tempSocketPath(t)
+	stop := runServer(t, sockPath)
+	defer stop()
+
+	const N = 10
+	errs := make(chan error, N)
+	for range N {
+		go func() {
+			conn, err := dialAndHandshake(sockPath)
+			if err != nil {
+				errs <- err
+				return
+			}
+			defer mustClose(t, conn)
+			if werr := writeJSON(conn, PingRequest{Type: TypePing, Version: ProtocolVersion}); werr != nil {
+				errs <- werr
+				return
+			}
+			env, _, rerr := readEnvelope(bufio.NewReader(conn))
+			if rerr != nil {
+				errs <- rerr
+				return
+			}
+			if env.Type != TypePong {
+				errs <- fmt.Errorf("got %q, want %q", env.Type, TypePong)
+				return
+			}
+			errs <- nil
+		}()
+	}
+	for range N {
+		if err := <-errs; err != nil {
+			t.Errorf("client err: %v", err)
+		}
+	}
+}

--- a/internal/agent/server_test.go
+++ b/internal/agent/server_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -288,7 +289,14 @@ func TestServer_ShutdownRemovesSocket(t *testing.T) {
 	}
 }
 
+// testSigtermMutex serializes tests that send process-level signals so
+// they don't fire each other's handlers when run with t.Parallel().
+var testSigtermMutex sync.Mutex
+
 func TestServer_SIGTERMRemovesSocket(t *testing.T) {
+	testSigtermMutex.Lock()
+	defer testSigtermMutex.Unlock()
+
 	sockPath := tempSocketPath(t)
 	srv, err := Listen(sockPath)
 	if err != nil {

--- a/internal/agent/server_test.go
+++ b/internal/agent/server_test.go
@@ -81,6 +81,18 @@ func runServer(t *testing.T, sockPath string) func() {
 	}
 }
 
+func TestServer_SocketPathGetter(t *testing.T) {
+	sockPath := tempSocketPath(t)
+	srv, err := Listen(sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mustClose(t, srv)
+	if got := srv.SocketPath(); got != sockPath {
+		t.Errorf("SocketPath() = %q, want %q", got, sockPath)
+	}
+}
+
 func TestServer_HelloHandshake(t *testing.T) {
 	sockPath := tempSocketPath(t)
 	stop := runServer(t, sockPath)

--- a/internal/agent/spawn.go
+++ b/internal/agent/spawn.go
@@ -226,9 +226,9 @@ func (l *spawnLock) release() {
 	if l.file == nil {
 		return
 	}
-	if err := syscall.Flock(int(l.file.Fd()), syscall.LOCK_UN); err != nil {
-		fmt.Fprintf(os.Stderr, "warning: release spawn lock: %v\n", err) //nolint:errcheck // best-effort warning
-	}
+	// flock(2) is associated with the open file description; closing the
+	// last fd referring to it releases the advisory lock. We hold the
+	// only reference, so close alone is sufficient.
 	closeOrLog(l.file, "spawn lock file")
 }
 

--- a/internal/agent/spawn.go
+++ b/internal/agent/spawn.go
@@ -1,0 +1,250 @@
+package agent
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"time"
+)
+
+// dialTimeout caps each individual connect attempt. Connecting to a
+// local Unix socket is fast (single-digit milliseconds even loaded);
+// 500ms is generous without being a hang.
+const dialTimeout = 500 * time.Millisecond
+
+// spawnPollInterval is how often EnsureAgent re-tries connecting after
+// it has launched a daemon, waiting for the socket to appear.
+const spawnPollInterval = 20 * time.Millisecond
+
+// SpawnTimeout is the default upper bound on EnsureAgent — the full
+// budget for "try existing, take lock, spawn, wait for socket." Exposed
+// (capitalized) so tests can override with a shorter value.
+const SpawnTimeout = 3 * time.Second
+
+// AgentSpawnCommand returns the exec.Cmd to spawn when EnsureAgent needs
+// to launch a daemon. By default invokes `<self> agent --socket <path>`.
+// Tests overwrite to point at a helper that runs the agent in-process
+// (via test-binary re-exec) and can hand the socket path through env
+// vars instead of fighting flag.Parse over an unrecognized --socket.
+var AgentSpawnCommand = func(sockPath string) (*exec.Cmd, error) {
+	self, err := os.Executable()
+	if err != nil {
+		return nil, fmt.Errorf("locate agent binary: %w", err)
+	}
+	return exec.Command(self, "agent", "--socket", sockPath), nil //nolint:gosec // self from os.Executable; sockPath validated upstream
+}
+
+// agentLogFile is the seam for redirecting the spawned daemon's stderr.
+// Production opens the user's cache log file; tests redirect to /dev/null
+// or a per-test path so they don't pollute the user's real cache.
+var agentLogFile = openAgentLog
+
+// EnsureAgent connects to the agent at the canonical socket path,
+// auto-spawning a daemon if no live agent is reachable. Returns a
+// connection that has already completed the hello handshake.
+//
+// The caller owns the returned connection and must Close it.
+func EnsureAgent() (*net.UnixConn, error) {
+	sockPath, err := SocketPath()
+	if err != nil {
+		return nil, err
+	}
+
+	// Fast path: agent already running and answering.
+	if conn, err := dialAndHandshake(sockPath); err == nil {
+		return conn, nil
+	}
+
+	// Slow path: serialize spawn attempts via a flock on a sibling lock
+	// file. Two concurrent EnsureAgent callers race here; the loser
+	// re-dials under the lock and short-circuits if the winner spawned
+	// a working agent in the meantime.
+	lockPath := sockPath + ".spawn.lock"
+	lock, err := acquireSpawnLock(lockPath)
+	if err != nil {
+		return nil, fmt.Errorf("acquire spawn lock: %w", err)
+	}
+	defer lock.release()
+
+	// Re-check under the lock — another EnsureAgent caller may have
+	// already spawned an agent while we waited.
+	if conn, err := dialAndHandshake(sockPath); err == nil {
+		return conn, nil
+	}
+
+	// Remove any stale socket file before spawning so the agent's own
+	// Listen() doesn't refuse with "agent already running."
+	if _, err := os.Stat(sockPath); err == nil {
+		if rerr := os.Remove(sockPath); rerr != nil && !errors.Is(rerr, os.ErrNotExist) {
+			return nil, fmt.Errorf("remove stale socket: %w", rerr)
+		}
+	}
+
+	if err := spawnAgent(sockPath); err != nil {
+		return nil, fmt.Errorf("spawn agent: %w", err)
+	}
+
+	// Poll for the socket. The agent typically binds within ~50ms on a
+	// warm machine; SpawnTimeout caps the patience.
+	deadline := time.Now().Add(SpawnTimeout)
+	for time.Now().Before(deadline) {
+		if conn, err := dialAndHandshake(sockPath); err == nil {
+			return conn, nil
+		}
+		time.Sleep(spawnPollInterval)
+	}
+	return nil, fmt.Errorf("agent did not bind socket within %s", SpawnTimeout)
+}
+
+// DialExisting connects to a running agent without auto-spawning. Used
+// by control paths where "no agent" should mean "nothing to do," not
+// "start one."
+func DialExisting() (*net.UnixConn, error) {
+	sockPath, err := SocketPath()
+	if err != nil {
+		return nil, err
+	}
+	return dialAndHandshake(sockPath)
+}
+
+// dialAndHandshake opens a connection to sockPath and performs the hello
+// handshake. Returns the connection only if the handshake succeeded with
+// a matching protocol version; otherwise closes the connection and
+// returns an error.
+func dialAndHandshake(sockPath string) (*net.UnixConn, error) {
+	raw, err := net.DialTimeout("unix", sockPath, dialTimeout)
+	if err != nil {
+		return nil, err
+	}
+	conn, ok := raw.(*net.UnixConn)
+	if !ok {
+		closeOrLog(raw, "non-Unix dial result")
+		return nil, fmt.Errorf("dialed connection is not *net.UnixConn (%T)", raw)
+	}
+
+	if err := writeJSON(conn, HelloRequest{Type: TypeHello, Version: ProtocolVersion}); err != nil {
+		closeOrLog(conn, "agent conn after hello write fail")
+		return nil, fmt.Errorf("send hello: %w", err)
+	}
+
+	r := bufio.NewReader(conn)
+	env, raw2, err := readEnvelope(r)
+	if err != nil {
+		closeOrLog(conn, "agent conn after hello_ack read fail")
+		return nil, fmt.Errorf("read hello_ack: %w", err)
+	}
+	switch env.Type {
+	case TypeHelloAck:
+		if env.Version != ProtocolVersion {
+			closeOrLog(conn, "agent conn after version mismatch")
+			return nil, fmt.Errorf("agent protocol version %d != client %d", env.Version, ProtocolVersion)
+		}
+		var ack HelloResponse
+		if err := decodeMessage(raw2, &ack); err != nil {
+			closeOrLog(conn, "agent conn after hello_ack decode fail")
+			return nil, err
+		}
+		return conn, nil
+	case TypeError:
+		var e ErrorResponse
+		if derr := decodeMessage(raw2, &e); derr != nil {
+			closeOrLog(conn, "agent conn after error decode fail")
+			return nil, fmt.Errorf("agent rejected hello (and error payload undecodable): %w", derr)
+		}
+		closeOrLog(conn, "agent conn after rejection")
+		return nil, fmt.Errorf("agent rejected hello: %s — %s", e.Code, e.Message)
+	default:
+		closeOrLog(conn, "agent conn after unexpected response")
+		return nil, fmt.Errorf("unexpected response type %q to hello", env.Type)
+	}
+}
+
+// spawnAgent forks the agent daemon as a detached child process. Stderr
+// is redirected to a log file so the parent's terminal doesn't get
+// noise; the child runs in a new session (Setsid) so it survives the
+// parent's exit.
+func spawnAgent(sockPath string) error {
+	cmd, err := AgentSpawnCommand(sockPath)
+	if err != nil {
+		return err
+	}
+
+	logFile, err := agentLogFile()
+	if err != nil {
+		return err
+	}
+	// Don't close logFile here — the spawned process inherits the fd
+	// and will use it for the lifetime of the daemon. Closing in the
+	// parent would invalidate the inherited fd on macOS.
+
+	cmd.Stdin = nil
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setsid = true
+
+	if err := cmd.Start(); err != nil {
+		closeOrLog(logFile, "agent log file after spawn failure")
+		return fmt.Errorf("start agent: %w", err)
+	}
+	// Release the parent's reference; the child still has the inherited
+	// fd (dup'd during fork). Without this, the file descriptor leaks
+	// until the parent exits.
+	closeOrLog(logFile, "agent log file (parent-side fd)")
+	return nil
+}
+
+// openAgentLog opens the agent log file for appending. Caller is
+// responsible for closing the *os.File when done (or letting it be
+// inherited by a spawned process).
+func openAgentLog() (*os.File, error) {
+	path, err := LogPath()
+	if err != nil {
+		return nil, err
+	}
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o600) //nolint:gosec // path is <cache>/sesh/logs/agent.log; cache dir is per-user
+	if err != nil {
+		return nil, fmt.Errorf("open agent log %s: %w", path, err)
+	}
+	return f, nil
+}
+
+// spawnLock is the flock-backed sentinel used to serialize concurrent
+// spawn attempts.
+type spawnLock struct {
+	file *os.File
+}
+
+func (l *spawnLock) release() {
+	if l.file == nil {
+		return
+	}
+	if err := syscall.Flock(int(l.file.Fd()), syscall.LOCK_UN); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: release spawn lock: %v\n", err) //nolint:errcheck // best-effort warning
+	}
+	closeOrLog(l.file, "spawn lock file")
+}
+
+// acquireSpawnLock opens the lock file (creating it if needed) and takes
+// an exclusive flock. Blocks until acquired.
+func acquireSpawnLock(path string) (*spawnLock, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, fmt.Errorf("create lock dir: %w", err)
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600) //nolint:gosec // path is <cache>/sesh/agent.sock.spawn.lock
+	if err != nil {
+		return nil, fmt.Errorf("open spawn lock %s: %w", path, err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		closeOrLog(f, "spawn lock file after flock fail")
+		return nil, fmt.Errorf("flock spawn lock: %w", err)
+	}
+	return &spawnLock{file: f}, nil
+}

--- a/internal/agent/spawn_test.go
+++ b/internal/agent/spawn_test.go
@@ -1,0 +1,227 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestAgentHelperProcess re-executes the test binary as a foreground
+// agent daemon. Activated when SESH_TEST_AGENT_HELPER=1 is in the env;
+// otherwise returns immediately so this entry is a no-op in normal
+// `go test` runs.
+func TestAgentHelperProcess(_ *testing.T) {
+	if os.Getenv("SESH_TEST_AGENT_HELPER") != "1" {
+		return
+	}
+	sockPath := os.Getenv("SESH_TEST_AGENT_SOCKET")
+	if sockPath == "" {
+		os.Exit(2)
+	}
+	srv, err := Listen(sockPath)
+	if err != nil {
+		os.Exit(3)
+	}
+	if err := srv.Run(context.Background()); err != nil {
+		os.Exit(4)
+	}
+	os.Exit(0)
+}
+
+// useTestSpawn rewires AgentSpawnCommand + agentLogFile so EnsureAgent
+// spawns a helper-process agent under t.TempDir() instead of the user's
+// real cache directory. Restores both on test cleanup.
+func useTestSpawn(t *testing.T) {
+	t.Helper()
+	origSpawn := AgentSpawnCommand
+	origLog := agentLogFile
+	logPath := filepath.Join(t.TempDir(), "agent.log")
+	AgentSpawnCommand = func(sockPath string) (*exec.Cmd, error) {
+		cmd := exec.Command(os.Args[0], "-test.run=TestAgentHelperProcess", "-test.v=false") //nolint:gosec // re-execs test binary
+		cmd.Env = append(os.Environ(),
+			"SESH_TEST_AGENT_HELPER=1",
+			"SESH_TEST_AGENT_SOCKET="+sockPath,
+		)
+		return cmd, nil
+	}
+	agentLogFile = func() (*os.File, error) {
+		return os.OpenFile(logPath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o600) //nolint:gosec // path under t.TempDir
+	}
+	t.Cleanup(func() {
+		AgentSpawnCommand = origSpawn
+		agentLogFile = origLog
+	})
+}
+
+// useTempSocketEnv points SESH_AUTH_SOCK at a fresh path under /tmp so
+// SocketPath returns it and we don't touch the user's real cache.
+func useTempSocketEnv(t *testing.T) string {
+	t.Helper()
+	sockPath := tempSocketPath(t)
+	t.Setenv("SESH_AUTH_SOCK", sockPath)
+	return sockPath
+}
+
+// killTestSpawnedChildren sends SIGTERM to every child of the current
+// process. The helper-agent runs as a child; this reaps them between
+// tests so a misbehaving test doesn't leave a daemon answering on the
+// next test's socket path.
+func killTestSpawnedChildren(t *testing.T) {
+	t.Helper()
+	out, err := exec.Command("pgrep", "-P", strconv.Itoa(os.Getpid())).Output()
+	if err != nil {
+		// No children, or pgrep unavailable on this platform.
+		return
+	}
+	for line := range bytes.SplitSeq(out, []byte{'\n'}) {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+		pid, perr := strconv.Atoi(string(line))
+		if perr != nil || pid <= 0 {
+			continue
+		}
+		if kerr := syscall.Kill(pid, syscall.SIGTERM); kerr != nil && !errors.Is(kerr, syscall.ESRCH) {
+			t.Logf("kill pid %d: %v", pid, kerr)
+		}
+	}
+}
+
+// waitForSocketGone polls until the socket file disappears (or the
+// deadline expires). Used after killing the helper agent to confirm it
+// shut down cleanly.
+func waitForSocketGone(t *testing.T, sockPath string) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(sockPath); errors.Is(err, os.ErrNotExist) {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// cleanupAgent reaps any spawned helper agent for sockPath and waits
+// for the socket file to disappear. Defer this in tests that spawn.
+func cleanupAgent(t *testing.T, sockPath string) {
+	t.Helper()
+	killTestSpawnedChildren(t)
+	waitForSocketGone(t, sockPath)
+}
+
+func TestEnsureAgent_FastPathExisting(t *testing.T) {
+	sockPath := useTempSocketEnv(t)
+	useTestSpawn(t)
+
+	stop := runServer(t, sockPath)
+	defer stop()
+
+	conn, err := EnsureAgent()
+	if err != nil {
+		t.Fatalf("EnsureAgent: %v", err)
+	}
+	if err := conn.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEnsureAgent_SpawnsWhenMissing(t *testing.T) {
+	sockPath := useTempSocketEnv(t)
+	useTestSpawn(t)
+	defer cleanupAgent(t, sockPath)
+
+	conn, err := EnsureAgent()
+	if err != nil {
+		t.Fatalf("EnsureAgent: %v", err)
+	}
+	if err := conn.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(sockPath); err != nil {
+		t.Errorf("agent socket not present after spawn: %v", err)
+	}
+}
+
+func TestEnsureAgent_StaleSocketRemoved(t *testing.T) {
+	sockPath := useTempSocketEnv(t)
+	useTestSpawn(t)
+	defer cleanupAgent(t, sockPath)
+
+	if err := os.MkdirAll(filepath.Dir(sockPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(sockPath, []byte("stale"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	conn, err := EnsureAgent()
+	if err != nil {
+		t.Fatalf("EnsureAgent: %v", err)
+	}
+	if err := conn.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEnsureAgent_RaceSerializedExactlyOneSpawn(t *testing.T) {
+	sockPath := useTempSocketEnv(t)
+	useTestSpawn(t)
+	defer cleanupAgent(t, sockPath)
+
+	var (
+		wg       sync.WaitGroup
+		mu       sync.Mutex
+		spawnErr error
+	)
+	const N = 4
+	wg.Add(N)
+	for range N {
+		go func() {
+			defer wg.Done()
+			conn, err := EnsureAgent()
+			if err != nil {
+				mu.Lock()
+				if spawnErr == nil {
+					spawnErr = err
+				}
+				mu.Unlock()
+				return
+			}
+			if cerr := conn.Close(); cerr != nil {
+				mu.Lock()
+				if spawnErr == nil {
+					spawnErr = cerr
+				}
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+	if spawnErr != nil {
+		t.Fatalf("at least one EnsureAgent failed: %v", spawnErr)
+	}
+	// All succeeded → only one helper agent bound the socket. If two
+	// had won the spawn race, the loser's Listen would have errored
+	// with "agent already running," its handshake would have failed,
+	// and EnsureAgent would have returned an error.
+}
+
+func TestDialExisting_FailsWhenNoAgent(t *testing.T) {
+	useTempSocketEnv(t)
+	useTestSpawn(t)
+
+	conn, err := DialExisting()
+	if err == nil {
+		mustClose(t, conn)
+		t.Fatal("DialExisting should fail when no agent is running")
+	}
+}

--- a/sesh/cmd/sesh/agent_cmd.go
+++ b/sesh/cmd/sesh/agent_cmd.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/bashhack/sesh/internal/agent"
+)
+
+// runAgent is the entry point for the `sesh agent` subcommand. It runs
+// the agent daemon in the foreground until SIGTERM/SIGINT arrives, at
+// which point the listener closes and the socket file is removed.
+func runAgent(app *App, args []string) error {
+	fs := flag.NewFlagSet("agent", flag.ContinueOnError)
+	fs.SetOutput(app.Stderr)
+	socket := fs.String("socket", "", "Override the canonical socket path. Defaults to <cache>/sesh/agent.sock.")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	sockPath := *socket
+	if sockPath == "" {
+		var err error
+		sockPath, err = agent.SocketPath()
+		if err != nil {
+			return fmt.Errorf("resolve socket path: %w", err)
+		}
+	}
+
+	srv, err := agent.Listen(sockPath)
+	if err != nil {
+		return fmt.Errorf("start agent: %w", err)
+	}
+	// Banner write to stderr is best-effort — a closed parent stderr
+	// shouldn't kill an otherwise healthy daemon.
+	_, _ = fmt.Fprintf(app.Stderr, "sesh-agent listening at %s\n", srv.SocketPath()) //nolint:errcheck // best-effort banner
+
+	if err := srv.Run(context.Background()); err != nil {
+		return fmt.Errorf("agent: %w", err)
+	}
+	return nil
+}

--- a/sesh/cmd/sesh/agent_cmd_test.go
+++ b/sesh/cmd/sesh/agent_cmd_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// agentTestApp builds an App suitable for runAgent: buffered Stdin/out/err
+// and a no-op Exit. The stderr buffer isn't returned because runAgent
+// writes to it concurrently with the test goroutine; reading the buffer
+// from the test would race.
+func agentTestApp() *App {
+	return &App{
+		Stdin:  bytes.NewReader(nil),
+		Stdout: new(bytes.Buffer),
+		Stderr: new(bytes.Buffer),
+		Exit:   func(int) {},
+	}
+}
+
+// tempAgentSocket returns a short path suitable for binding (under /tmp
+// to stay under macOS's 104-char socket-path limit).
+func tempAgentSocket(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "ac")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() {
+		if rerr := os.RemoveAll(dir); rerr != nil {
+			t.Errorf("RemoveAll: %v", rerr)
+		}
+	})
+	return filepath.Join(dir, "s")
+}
+
+func TestRunAgent_RejectsUnknownFlag(t *testing.T) {
+	app := agentTestApp()
+	err := runAgent(app, []string{"--bogus"})
+	if err == nil {
+		t.Fatal("runAgent should reject unknown flag")
+	}
+}
+
+// waitForSocketBound polls for the socket file to appear, indicating
+// Listen succeeded. Cheaper than reading stderr concurrently — and avoids
+// the obvious data race on app.Stderr that a polling reader would hit.
+func waitForSocketBound(t *testing.T, sockPath string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(sockPath); err == nil {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("socket %q did not appear within 2s", sockPath)
+}
+
+func TestRunAgent_BindsAndShutsDownOnSIGTERM(t *testing.T) {
+	sockPath := tempAgentSocket(t)
+	app := agentTestApp()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- runAgent(app, []string{"--socket", sockPath})
+	}()
+	waitForSocketBound(t, sockPath)
+
+	conn, err := net.DialTimeout("unix", sockPath, 500*time.Millisecond)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	if err := conn.Close(); err != nil {
+		t.Errorf("close: %v", err)
+	}
+
+	if err := syscall.Kill(os.Getpid(), syscall.SIGTERM); err != nil {
+		t.Fatalf("send SIGTERM: %v", err)
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("runAgent returned err = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("runAgent didn't exit within 2s of SIGTERM")
+	}
+
+	if _, err := os.Stat(sockPath); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("socket should be removed after shutdown, stat err = %v", err)
+	}
+}
+
+func TestRunAgent_DefaultSocketPath(t *testing.T) {
+	// SESH_AUTH_SOCK override gives us a deterministic path without
+	// needing to peek at SocketPath's logic.
+	sockPath := tempAgentSocket(t)
+	t.Setenv("SESH_AUTH_SOCK", sockPath)
+
+	app := agentTestApp()
+	done := make(chan error, 1)
+	go func() {
+		done <- runAgent(app, nil) // no --socket flag → uses agent.SocketPath()
+	}()
+	waitForSocketBound(t, sockPath)
+
+	if err := syscall.Kill(os.Getpid(), syscall.SIGTERM); err != nil {
+		t.Fatalf("send SIGTERM: %v", err)
+	}
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runAgent didn't exit on SIGTERM")
+	}
+}

--- a/sesh/cmd/sesh/main.go
+++ b/sesh/cmd/sesh/main.go
@@ -81,7 +81,8 @@ func needsCredentialStore(args []string) bool {
 			"--version", "-version",
 			"--list-services", "-list-services",
 			"--migrate", "-migrate",
-			"--rekey", "-rekey":
+			"--rekey", "-rekey",
+			"agent":
 			return false
 		}
 	}
@@ -464,6 +465,12 @@ func run(app *App, args []string) {
 		case "--rekey", "-rekey":
 			rest := remainingArgs(args, arg)
 			if err := runRekey(app, rest, keychain.NewDefaultProvider()); err != nil {
+				fatal(app, err)
+			}
+			return
+		case "agent":
+			rest := remainingArgs(args, arg)
+			if err := runAgent(app, rest); err != nil {
 				fatal(app, err)
 			}
 			return


### PR DESCRIPTION
## Summary

Phase A of the `sesh-agent` initiative — the daemon foundation. **No user-visible behavior changes**; this PR's only purpose is to land the wire format, lifecycle, peer-cred check, and auto-spawn helper so that the key-handling work in the next PR has a stable substrate to build on.

## What this PR is

- `sesh agent` subcommand: binds a per-UID Unix socket at `<user-cache-dir>/sesh/agent.sock` (perm 0600), accepts connections, peer-cred-checks them, runs a version-handshake'd JSON-over-newline protocol, handles SIGTERM/SIGINT, removes the socket on shutdown.
- `internal/agent`: protocol structs (`HelloRequest`/`HelloResponse`/`PingRequest`/`PingResponse`/`ErrorResponse`), `Server`, auto-spawn helper (`EnsureAgent`), peer-cred check (build-tag-split for Linux's `SO_PEERCRED` vs macOS's `LOCAL_PEERCRED`), stale-socket cleanup on both sides, log-file redirection of spawned child's stderr.
- Phase A's only protocol messages: `hello` / `hello_ack` / `ping` / `pong` / `error`. No key handling.

## What this PR is NOT

- It does **not** route any sesh command through the agent. `buildKeySource` is unchanged. `SESH_KEY_SOURCE=password` still prompts on every command.
- It does **not** introduce idle timeout, `lock`, `status`, or `stop` (next phase).
- It does **not** ship launchd / systemd templates or threat-model docs (last phase).

## What the next PR will add

The follow-up routes the CLI's crypto through the agent: `unlock`, `decrypt`, `encrypt`, `status` messages plus an `AgentKeySource` that proxies decryption/encryption through the socket (raw key never leaves the agent — oracle model). After that PR, the every-command-re-prompts problem goes away.

## Test plan

- [x] `go test ./... -race -count=1` green
- [x] `make pre-commit` clean
- [x] Manual smoke confirms the wire format round-trips and SIGTERM cleans up the socket:

\`\`\`
rm -f /tmp/sesh-smoke.sock
./build/sesh agent --socket /tmp/sesh-smoke.sock &
sleep 0.3
printf '{\"type\":\"hello\",\"version\":1}\n{\"type\":\"ping\",\"version\":1}\n' \\
  | nc -U /tmp/sesh-smoke.sock
kill %1
\`\`\`

Got \`hello_ack\` (with the agent's PID) then \`pong\`; socket cleaned up on SIGTERM.

## Notable test coverage

- `protocol_test.go` — framing/encoding round-trips, version-bump tripwire.
- `server_test.go` — real-socket lifecycle: handshake, ping/pong, version mismatch rejection, non-hello-first rejection, unknown message types, stale socket cleanup, SIGTERM removal, concurrent client handling.
- `spawn_test.go` — re-execs the test binary as a helper agent via `-test.run=TestAgentHelperProcess` + env vars. Covers fast-path-existing, spawns-when-missing, stale-socket-removed, and race-serialized (4 concurrent EnsureAgent calls; exactly one daemon ends up bound).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "sesh agent" command to run a local background agent.
  * Clients now auto-spawn and connect to a per-user agent via a Unix socket.
  * Agent exposes a simple ping/hello wire protocol and writes persistent agent logs.

* **Bug Fixes / Reliability**
  * Agent cleans up stale sockets, handles concurrent spawns, and shuts down cleanly on SIGTERM.

* **Security**
  * Peer credential checks enforce that clients match the expected user.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bashhack/sesh/pull/40)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->